### PR TITLE
shading transitive geotools to private geospark

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -175,7 +175,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>2.1</version>
+                <version>3.2.1</version>
                 <executions>
                     <execution>
                         <phase>package</phase>
@@ -203,6 +203,12 @@
                                     </excludes>
                                 </filter>
                             </filters>
+                            <relocations>
+                            <relocation>
+                                <pattern>org.geotools</pattern>
+                                <shadedPattern>org.private.geospark.geotools</shadedPattern>
+                            </relocation>
+                        </relocations>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
## Is this PR related to a proposed Issue?
https://github.com/DataSystemsLab/GeoSpark/issues/410

## What changes were proposed in this PR?
shade transitive dependencies to not pollute classpath
upgrade maven shade plugin as the old one had bugs

## How was this patch tested?
run the included test suite

## Did this PR include necessary documentation updates?
none required