### PR TITLE
[SEDONA-19] Update JoinParams to not always set useIndex to false

### DIFF
--- a/core/src/main/java/org/apache/sedona/core/spatialOperator/JoinQuery.java
+++ b/core/src/main/java/org/apache/sedona/core/spatialOperator/JoinQuery.java
@@ -423,15 +423,12 @@ public class JoinQuery
 
         public JoinParams(boolean useIndex, boolean considerBoundaryIntersection)
         {
-            this.useIndex = useIndex;
-            this.considerBoundaryIntersection = considerBoundaryIntersection;
-            this.indexType = IndexType.RTREE;
-            this.joinBuildSide = JoinBuildSide.RIGHT;
+            this(useIndex, considerBoundaryIntersection, IndexType.RTREE, JoinBuildSide.RIGHT);
         }
 
-        public JoinParams(boolean considerBoundaryIntersection, IndexType polygonIndexType, JoinBuildSide joinBuildSide)
+        public JoinParams(boolean useIndex, boolean considerBoundaryIntersection, IndexType polygonIndexType, JoinBuildSide joinBuildSide)
         {
-            this.useIndex = false;
+            this.useIndex = useIndex;
             this.considerBoundaryIntersection = considerBoundaryIntersection;
             this.indexType = polygonIndexType;
             this.joinBuildSide = joinBuildSide;

--- a/core/src/test/java/org/apache/sedona/core/spatialOperator/LineStringJoinTest.java
+++ b/core/src/test/java/org/apache/sedona/core/spatialOperator/LineStringJoinTest.java
@@ -168,7 +168,7 @@ public class LineStringJoinTest
 
         partitionRdds(queryRDD, spatialRDD);
 
-        JoinQuery.JoinParams joinParams = new JoinQuery.JoinParams(true, indexType, JoinBuildSide.LEFT);
+        JoinQuery.JoinParams joinParams = new JoinQuery.JoinParams(true, true, indexType, JoinBuildSide.LEFT);
         List<Tuple2<Polygon, LineString>> results = JoinQuery.spatialJoin(queryRDD, spatialRDD, joinParams).collect();
 
         sanityCheckFlatJoinResults(results);

--- a/core/src/test/java/org/apache/sedona/core/spatialOperator/PointJoinTest.java
+++ b/core/src/test/java/org/apache/sedona/core/spatialOperator/PointJoinTest.java
@@ -226,7 +226,7 @@ public class PointJoinTest
 
         partitionRdds(queryRDD, spatialRDD);
 
-        JoinQuery.JoinParams joinParams = new JoinQuery.JoinParams(true, indexType, JoinBuildSide.LEFT);
+        JoinQuery.JoinParams joinParams = new JoinQuery.JoinParams(true, true, indexType, JoinBuildSide.LEFT);
         List<Tuple2<Polygon, Point>> results = JoinQuery.spatialJoin(queryRDD, spatialRDD, joinParams).collect();
 
         sanityCheckFlatJoinResults(results);

--- a/core/src/test/java/org/apache/sedona/core/spatialOperator/PolygonJoinTest.java
+++ b/core/src/test/java/org/apache/sedona/core/spatialOperator/PolygonJoinTest.java
@@ -120,7 +120,7 @@ public class PolygonJoinTest
         final PolygonRDD spatialRDD = createPolygonRDD(InputLocation);
         partitionRdds(queryRDD, spatialRDD);
 
-        final JoinQuery.JoinParams joinParams = new JoinQuery.JoinParams(intersects, indexType, JoinBuildSide.LEFT);
+        final JoinQuery.JoinParams joinParams = new JoinQuery.JoinParams(true, intersects, indexType, JoinBuildSide.LEFT);
         final List<Tuple2<Polygon, Polygon>> results = JoinQuery.spatialJoin(queryRDD, spatialRDD, joinParams).collect();
         sanityCheckFlatJoinResults(results);
 

--- a/core/src/test/java/org/apache/sedona/core/spatialOperator/RectangleJoinTest.java
+++ b/core/src/test/java/org/apache/sedona/core/spatialOperator/RectangleJoinTest.java
@@ -164,7 +164,7 @@ public class RectangleJoinTest
 
         partitionRdds(queryRDD, spatialRDD);
 
-        JoinQuery.JoinParams joinParams = new JoinQuery.JoinParams(true, indexType, JoinBuildSide.LEFT);
+        JoinQuery.JoinParams joinParams = new JoinQuery.JoinParams(true, true, indexType, JoinBuildSide.LEFT);
         List<Tuple2<Polygon, Polygon>> result = JoinQuery.spatialJoin(queryRDD, spatialRDD, joinParams).collect();
 
         sanityCheckFlatJoinResults(result);

--- a/core/src/test/scala/org/apache/sedona/core/scalaTest.scala
+++ b/core/src/test/scala/org/apache/sedona/core/scalaTest.scala
@@ -147,7 +147,7 @@ class scalaTest extends SparkUtil {
     queryWindowRDD.spatialPartitioning(objectRDD.getPartitioner)
 
     for (i <- 1 to eachQueryLoopTimes) {
-      val joinParams = new JoinParams(false, PolygonRDDIndexType, JoinBuildSide.LEFT)
+      val joinParams = new JoinParams(true, false, PolygonRDDIndexType, JoinBuildSide.LEFT)
       val resultSize = JoinQuery.spatialJoin(queryWindowRDD, objectRDD, joinParams).count()
     }
   }

--- a/python-adapter/src/main/scala/org.apache.sedona.python.wrapper/adapters/JoinParamsAdapter.scala
+++ b/python-adapter/src/main/scala/org.apache.sedona.python.wrapper/adapters/JoinParamsAdapter.scala
@@ -23,9 +23,9 @@ import org.apache.sedona.core.enums.{IndexType, JoinBuildSide}
 import org.apache.sedona.core.spatialOperator.JoinQuery.JoinParams
 
 object JoinParamsAdapter {
-  def createJoinParams(useIndex: Boolean = false, indexType: String, joinBuildSide: String): JoinParams = {
+  def createJoinParams(useIndex: Boolean = true, considerBoundaryIntersection: Boolean = false, indexType: String, joinBuildSide: String): JoinParams = {
     val buildSide = JoinBuildSide.getBuildSide(joinBuildSide)
     val currIndexType = IndexType.getIndexType(indexType)
-    new JoinParams(useIndex, currIndexType, buildSide)
+    new JoinParams(useIndex, considerBoundaryIntersection, currIndexType, buildSide)
   }
 }

--- a/python/sedona/core/spatialOperator/join_params.py
+++ b/python/sedona/core/spatialOperator/join_params.py
@@ -25,21 +25,23 @@ from sedona.core.jvm.abstract import JvmObject
 @attr.s
 class JoinParams:
     useIndex = attr.ib(type=bool, default=True)
+    considerBoundaryIntersection = attr.ib(type=bool, default=False)
     indexType = attr.ib(type=str, default=IndexType.RTREE)
     joinBuildSide = attr.ib(type=str, default=JoinBuildSide.LEFT)
 
     def jvm_instance(self, jvm):
-        return JvmJoinParams(jvm, self.useIndex, self.indexType, self.joinBuildSide).jvm_instance
+        return JvmJoinParams(jvm, self.useIndex, self.considerBoundaryIntersection, self.indexType, self.joinBuildSide).jvm_instance
 
 
 @attr.s
 class JvmJoinParams(JvmObject):
     useIndex = attr.ib(type=bool, default=True)
+    considerBoundaryIntersection = attr.ib(type=bool, default=False)
     indexType = attr.ib(type=str, default=IndexType.RTREE)
     joinBuildSide = attr.ib(type=str, default=JoinBuildSide.LEFT)
 
     def _create_jvm_instance(self):
-        return self.jvm_reference(self.useIndex, self.indexType.value, self.joinBuildSide)
+        return self.jvm_reference(self.useIndex, self.considerBoundaryIntersection, self.indexType.value, self.joinBuildSide)
 
     @property
     def jvm_reference(self):

--- a/python/tests/core/test_avoiding_python_jvm_serde_to_rdd.py
+++ b/python/tests/core/test_avoiding_python_jvm_serde_to_rdd.py
@@ -44,7 +44,7 @@ class TestOmitPythonJvmSerdeToRDD(TestBase):
         poi_point_rdd.spatialPartitioning(GridType.QUADTREE)
         areas_polygon_rdd.spatialPartitioning(poi_point_rdd.getPartitioner())
 
-        jvm_sedona_rdd = JoinQueryRaw.spatialJoin(poi_point_rdd, areas_polygon_rdd, JoinParams())
+        jvm_sedona_rdd = JoinQueryRaw.spatialJoin(poi_point_rdd, areas_polygon_rdd, JoinParams(considerBoundaryIntersection=True))
         sedona_rdd = jvm_sedona_rdd.to_rdd().collect()
         assert sedona_rdd.__len__() == 5
 

--- a/python/tests/core/test_rdd.py
+++ b/python/tests/core/test_rdd.py
@@ -269,7 +269,7 @@ class TestSpatialRDD(TestBase):
         query_window_rdd.spatialPartitioning(object_rdd.getPartitioner())
 
         for i in range(each_query_loop_times):
-            join_params = JoinParams(False, polygon_rdd_index_type, JoinBuildSide.LEFT)
+            join_params = JoinParams(True, False, polygon_rdd_index_type, JoinBuildSide.LEFT)
             resultSize = JoinQuery.spatialJoin(
                 query_window_rdd,
                 object_rdd,

--- a/python/tests/spatial_operator/test_linestring_join.py
+++ b/python/tests/spatial_operator/test_linestring_join.py
@@ -78,7 +78,7 @@ class TestRectangleJoin(TestJoinBase):
 
         self.partition_rdds(query_rdd, spatial_rdd, grid_type)
 
-        join_params = JoinParams(True, index_type, JoinBuildSide.LEFT)
+        join_params = JoinParams(True, True, index_type, JoinBuildSide.LEFT)
         result = JoinQuery.spatialJoin(query_rdd, spatial_rdd, join_params).collect()
 
         self.sanity_check_flat_join_results(result)

--- a/python/tests/spatial_operator/test_point_join.py
+++ b/python/tests/spatial_operator/test_point_join.py
@@ -152,7 +152,7 @@ class TestRectangleJoin(TestJoinBase):
         spatial_rdd = self.create_point_rdd(input_location, splitter, num_partitions)
 
         self.partition_rdds(query_rdd, spatial_rdd, grid_type)
-        join_params = JoinParams(True, index_type, JoinBuildSide.LEFT)
+        join_params = JoinParams(True, True, index_type, JoinBuildSide.LEFT)
         results = JoinQuery.spatialJoin(query_rdd, spatial_rdd, join_params).collect()
 
         self.sanity_check_flat_join_results(results)

--- a/python/tests/spatial_operator/test_polygon_join.py
+++ b/python/tests/spatial_operator/test_polygon_join.py
@@ -79,7 +79,7 @@ class TestRectangleJoin(TestJoinBase):
 
         self.partition_rdds(query_rdd, spatial_rdd, grid_type)
 
-        join_params = JoinParams(intersects, index_type, JoinBuildSide.LEFT)
+        join_params = JoinParams(True, intersects, index_type, JoinBuildSide.LEFT)
         result = JoinQuery.spatialJoin(query_rdd, spatial_rdd, join_params).collect()
 
         self.sanity_check_flat_join_results(result)

--- a/python/tests/spatial_operator/test_rectangle_join.py
+++ b/python/tests/spatial_operator/test_rectangle_join.py
@@ -84,7 +84,7 @@ class TestRectangleJoin(TestJoinBase):
 
         self.partition_rdds(query_rdd, spatial_rdd, grid_type)
 
-        join_params = JoinParams(True, index_type, JoinBuildSide.LEFT)
+        join_params = JoinParams(True, True, index_type, JoinBuildSide.LEFT)
         result = JoinQuery.spatialJoin(query_rdd, spatial_rdd, join_params).collect()
 
         self.sanity_check_flat_join_results(result)

--- a/python/tests/sql/test_function.py
+++ b/python/tests/sql/test_function.py
@@ -484,7 +484,7 @@ class TestPredicateJoin(TestBase):
         dumped_points = geometry_df.selectExpr("ST_DumpPoints(geom) as geom") \
             .select(explode(col("geom")).alias("geom"))
 
-        assert(dumped_points.count(), 10)
+        assert(dumped_points.count() == 10)
 
         collected_points = [geom_row[0] for geom_row in dumped_points.selectExpr("ST_AsText(geom)").collect()]
         assert(collected_points == expected_points)

--- a/sql/src/main/scala/org/apache/spark/sql/sedona_sql/strategy/join/TraitJoinQueryExec.scala
+++ b/sql/src/main/scala/org/apache/spark/sql/sedona_sql/strategy/join/TraitJoinQueryExec.scala
@@ -122,7 +122,7 @@ Predicate.create(extraCondition.get, left.output ++ right.output).eval _ // SPAR
     }
 
 
-    val joinParams = new JoinParams(intersects, sedonaConf.getIndexType, sedonaConf.getJoinBuildSide)
+    val joinParams = new JoinParams(sedonaConf.getUseIndex, intersects, sedonaConf.getIndexType, sedonaConf.getJoinBuildSide)
 
     //logInfo(s"leftShape count ${leftShapes.spatialPartitionedRDD.count()}")
     //logInfo(s"rightShape count ${rightShapes.spatialPartitionedRDD.count()}")


### PR DESCRIPTION
## Is this PR related to a proposed Issue?
https://issues.apache.org/jira/browse/SEDONA-19

## What changes were proposed in this PR?
Fixes a bug where useIndex was always false when setting the index type and index build side. 

## How was this patch tested?
Existing tests still pass, but not sure how you would check if the index was used or not.

## Did this PR include necessary documentation updates?
Updates the code to reflect what the documentation already says.
