### PR TITLE
[SEDONA-20] Add custom equals method to GeometryUDT

### DIFF
--- a/sql/src/main/scala/org/apache/spark/sql/sedona_sql/UDT/GeometryUDT.scala
+++ b/sql/src/main/scala/org/apache/spark/sql/sedona_sql/UDT/GeometryUDT.scala
@@ -49,6 +49,13 @@ class GeometryUDT extends UserDefinedType[Geometry] {
       case other: Any => other
     }
   }
+
+  override def equals(other: Any): Boolean = other match {
+    case _: UserDefinedType[_] => isInstanceOf[GeometryUDT]
+    case _ => false
+  }
+
+  override def hashCode(): Int = super.hashCode()
 }
 
 case object GeometryUDT extends org.apache.spark.sql.sedona_sql.UDT.GeometryUDT with scala.Serializable

--- a/sql/src/test/scala/org/apache/sedona/sql/GeometryUdtTestScala.scala
+++ b/sql/src/test/scala/org/apache/sedona/sql/GeometryUdtTestScala.scala
@@ -18,15 +18,14 @@
  */
 package org.apache.sedona.sql
 
-import org.apache.spark.sql.{DataFrame, SaveMode}
+import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.functions.expr
+import org.apache.spark.sql.sedona_sql.UDT.GeometryUDT
 import org.apache.spark.sql.types.{DataType, StructType}
 import org.junit.rules.TemporaryFolder
 import org.locationtech.jts.geom.Geometry
 import org.locationtech.jts.io.WKTReader
 import org.scalatest.BeforeAndAfter
-
-import org.apache.spark.sql.sedona_sql.UDT.GeometryUDT
 
 class GeometryUdtTestScala extends TestBaseScala with BeforeAndAfter {
 
@@ -55,7 +54,7 @@ class GeometryUdtTestScala extends TestBaseScala with BeforeAndAfter {
     }
 
     it("Should be able to render and parse JSON schema") {
-     assert(DataType.fromJson(dataFrame.schema.json).asInstanceOf[StructType].equals(dataFrame.schema))
+      assert(DataType.fromJson(dataFrame.schema.json).asInstanceOf[StructType].equals(dataFrame.schema))
     }
 
     it("Case object and new instance should be equals") {

--- a/sql/src/test/scala/org/apache/sedona/sql/GeometryUdtTestScala.scala
+++ b/sql/src/test/scala/org/apache/sedona/sql/GeometryUdtTestScala.scala
@@ -18,13 +18,15 @@
  */
 package org.apache.sedona.sql
 
-import org.apache.spark.sql.DataFrame
+import org.apache.spark.sql.{DataFrame, SaveMode}
 import org.apache.spark.sql.functions.expr
 import org.apache.spark.sql.types.{DataType, StructType}
 import org.junit.rules.TemporaryFolder
 import org.locationtech.jts.geom.Geometry
 import org.locationtech.jts.io.WKTReader
 import org.scalatest.BeforeAndAfter
+
+import org.apache.spark.sql.sedona_sql.UDT.GeometryUDT
 
 class GeometryUdtTestScala extends TestBaseScala with BeforeAndAfter {
 
@@ -54,6 +56,10 @@ class GeometryUdtTestScala extends TestBaseScala with BeforeAndAfter {
 
     it("Should be able to render and parse JSON schema") {
      assert(DataType.fromJson(dataFrame.schema.json).asInstanceOf[StructType].equals(dataFrame.schema))
+    }
+
+    it("Case object and new instance should be equals") {
+      assert(GeometryUDT.equals(new GeometryUDT))
     }
   }
 


### PR DESCRIPTION
## Is this PR related to a proposed Issue?
SEDONA-20

## What changes were proposed in this PR?
Implementation of a custom equals method for GeometryUDT because auf changes in the base class UserDefinedType made in Spark 3.0.2

## How was this patch tested?
Unit test

## Did this PR include necessary documentation updates?
No

<sup>Michael Merg (<michael.merg@daimler.com>), Mercedes-Benz AG on behalf of MBition GmbH ([Imprint](https://github.com/Daimler/daimler-foss/blob/master/LEGAL_IMPRINT.md))</sup>