### PR TITLE
[SEDONA-26] Add broadcast join support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@
 /conf/
 /log/
 /site/
+/.bloop/
+/.metals/
+/.vscode/

--- a/docs/api/sql/GeoSparkSQL-Optimizer.md
+++ b/docs/api/sql/GeoSparkSQL-Optimizer.md
@@ -107,6 +107,8 @@ BroadcastIndexJoin pointshape#52: geometry, BuildRight, BuildLeft, true, 2.0 ST_
       +- FileScan csv
 ```
 
+Note: Ff the distance is an expression, it is only evaluated on the first argument to ST_Distance (`pointDf1` above).
+
 ## Predicate pushdown
 
 Introduction: Given a join query and a predicate in the same WHERE clause, first executes the Predicate as a filter, then executes the join query*

--- a/docs/api/sql/GeoSparkSQL-Optimizer.md
+++ b/docs/api/sql/GeoSparkSQL-Optimizer.md
@@ -72,6 +72,41 @@ DistanceJoin pointshape1#12: geometry, pointshape2#33: geometry, 2.0, true
 !!!warning
 	Sedona doesn't control the distance's unit (degree or meter). It is same with the geometry. To change the geometry's unit, please transform the coordinate reference system. See [ST_Transform](GeoSparkSQL-Function.md#st_transform).
 
+## Broadcast join
+Introduction: Perform a range join or distance join but broadcast one of the sides of the join. This maintains the partitioning of the non-broadcast side and doesn't require a shuffle.
+
+```Scala
+pointDf.alias("pointDf").join(broadcast(polygonDf).alias("polygonDf"), expr("ST_Contains(polygonDf.polygonshape, pointDf.pointshape)"))
+```
+
+Spark SQL Physical plan:
+```
+== Physical Plan ==
+BroadcastIndexJoin pointshape#52: geometry, BuildRight, BuildRight, false ST_Contains(polygonshape#30, pointshape#52)
+:- Project [st_point(cast(_c0#48 as decimal(24,20)), cast(_c1#49 as decimal(24,20))) AS pointshape#52]
+:  +- FileScan csv
++- SpatialIndex polygonshape#30: geometry, QUADTREE, [id=#62]
+   +- Project [st_polygonfromenvelope(cast(_c0#22 as decimal(24,20)), cast(_c1#23 as decimal(24,20)), cast(_c2#24 as decimal(24,20)), cast(_c3#25 as decimal(24,20))) AS polygonshape#30]
+      +- FileScan csv
+```
+
+This also works for distance joins:
+
+```Scala
+pointDf1.alias("pointDf1").join(broadcast(pointDf2).alias("pointDf2"), expr("ST_Distance(pointDf1.pointshape, pointDf2.pointshape) <= 2"))
+```
+
+Spark SQL Physical plan:
+```
+== Physical Plan ==
+BroadcastIndexJoin pointshape#52: geometry, BuildRight, BuildLeft, true, 2.0 ST_Distance(pointshape#52, pointshape#415) <= 2.0
+:- Project [st_point(cast(_c0#48 as decimal(24,20)), cast(_c1#49 as decimal(24,20))) AS pointshape#52]
+:  +- FileScan csv
++- SpatialIndex pointshape#415: geometry, QUADTREE, [id=#1068]
+   +- Project [st_point(cast(_c0#48 as decimal(24,20)), cast(_c1#49 as decimal(24,20))) AS pointshape#415]
+      +- FileScan csv
+```
+
 ## Predicate pushdown
 
 Introduction: Given a join query and a predicate in the same WHERE clause, first executes the Predicate as a filter, then executes the join query*

--- a/docs/api/sql/GeoSparkSQL-Overview.md
+++ b/docs/api/sql/GeoSparkSQL-Overview.md
@@ -6,6 +6,11 @@ SedonaSQL supports SQL/MM Part3 Spatial SQL Standard. It includes four kinds of 
 var myDataFrame = sparkSession.sql("YOUR_SQL")
 ```
 
+Alternatively, `expr` and `selectExpr` can be used:
+```Scala
+myDataFrame.withColumn("geometry", expr("ST_*")).selectExpr("ST_*")
+```
+
 * Constructor: Construct a Geometry given an input string or coordinates
 	* Example: ST_GeomFromWKT (string). Create a Geometry from a WKT String.
 	* Documentation: [Here](../GeoSparkSQL-Constructor)

--- a/python-adapter/.gitignore
+++ b/python-adapter/.gitignore
@@ -1,1 +1,5 @@
 /target/
+bin
+/.settings
+/.classpath
+/.project

--- a/spark-version-converter.py
+++ b/spark-version-converter.py
@@ -23,7 +23,8 @@ spark2_anchor = 'SPARK2 anchor'
 spark3_anchor = 'SPARK3 anchor'
 files = ['sql/src/main/scala/org/apache/sedona/sql/UDF/UdfRegistrator.scala',
          'sql/src/main/scala/org/apache/spark/sql/sedona_sql/strategy/join/TraitJoinQueryExec.scala',
-         'sql/src/main/scala/org/apache/spark/sql/sedona_sql/strategy/join/JoinQueryDetector.scala']
+         'sql/src/main/scala/org/apache/spark/sql/sedona_sql/strategy/join/JoinQueryDetector.scala',
+         'sql/src/main/scala/org/apache/spark/sql/sedona_sql/strategy/join/BroadcastIndexJoinExec.scala']
 
 def switch_version(line):
     if line[:2] == '//':

--- a/sql/src/main/scala/org/apache/sedona/sql/utils/SedonaSQLRegistrator.scala
+++ b/sql/src/main/scala/org/apache/sedona/sql/utils/SedonaSQLRegistrator.scala
@@ -20,18 +20,16 @@ package org.apache.sedona.sql.utils
 
 import org.apache.sedona.sql.UDF.UdfRegistrator
 import org.apache.sedona.sql.UDT.UdtRegistrator
-import org.apache.spark.sql.sedona_sql.strategy.join.JoinQueryDetector
 import org.apache.spark.sql.{SQLContext, SparkSession}
+import org.apache.spark.sql.sedona_sql.strategy.join.JoinQueryDetector
 
 object SedonaSQLRegistrator {
   def registerAll(sqlContext: SQLContext): Unit = {
-    sqlContext.experimental.extraStrategies = JoinQueryDetector :: Nil
-    UdtRegistrator.registerAll()
-    UdfRegistrator.registerAll(sqlContext)
+    registerAll(sqlContext.sparkSession)
   }
 
   def registerAll(sparkSession: SparkSession): Unit = {
-    sparkSession.experimental.extraStrategies = JoinQueryDetector :: Nil
+    sparkSession.experimental.extraStrategies = new JoinQueryDetector(sparkSession) :: Nil
     UdtRegistrator.registerAll()
     UdfRegistrator.registerAll(sparkSession)
   }

--- a/sql/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/Predicates.scala
+++ b/sql/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/Predicates.scala
@@ -25,13 +25,15 @@ import org.apache.spark.sql.catalyst.expressions.codegen.CodegenFallback
 import org.apache.spark.sql.catalyst.util.ArrayData
 import org.apache.spark.sql.types.BooleanType
 
+abstract class ST_Predicate extends Expression
+
 /**
   * Test if leftGeometry full contains rightGeometry
   *
   * @param inputExpressions
   */
 case class ST_Contains(inputExpressions: Seq[Expression])
-  extends Expression with CodegenFallback {
+  extends ST_Predicate with CodegenFallback {
 
   // This is a binary expression
   assert(inputExpressions.length == 2)
@@ -62,7 +64,7 @@ case class ST_Contains(inputExpressions: Seq[Expression])
   * @param inputExpressions
   */
 case class ST_Intersects(inputExpressions: Seq[Expression])
-  extends Expression with CodegenFallback {
+  extends ST_Predicate with CodegenFallback {
   override def nullable: Boolean = false
 
   // This is a binary expression
@@ -92,7 +94,7 @@ case class ST_Intersects(inputExpressions: Seq[Expression])
   * @param inputExpressions
   */
 case class ST_Within(inputExpressions: Seq[Expression])
-  extends Expression with CodegenFallback {
+  extends ST_Predicate with CodegenFallback {
   override def nullable: Boolean = false
 
   // This is a binary expression
@@ -123,7 +125,7 @@ case class ST_Within(inputExpressions: Seq[Expression])
   * @param inputExpressions
   */
 case class ST_Crosses(inputExpressions: Seq[Expression])
-  extends Expression with CodegenFallback {
+  extends ST_Predicate with CodegenFallback {
   override def nullable: Boolean = false
 
   override def toString: String = s" **${ST_Crosses.getClass.getName}**  "
@@ -153,7 +155,7 @@ case class ST_Crosses(inputExpressions: Seq[Expression])
   * @param inputExpressions
   */
 case class ST_Overlaps(inputExpressions: Seq[Expression])
-  extends Expression with CodegenFallback {
+  extends ST_Predicate with CodegenFallback {
   override def nullable: Boolean = false
 
   // This is a binary expression
@@ -183,7 +185,7 @@ case class ST_Overlaps(inputExpressions: Seq[Expression])
   * @param inputExpressions
   */
 case class ST_Touches(inputExpressions: Seq[Expression])
-  extends Expression with CodegenFallback {
+  extends ST_Predicate with CodegenFallback {
   override def nullable: Boolean = false
 
   // This is a binary expression
@@ -213,7 +215,7 @@ case class ST_Touches(inputExpressions: Seq[Expression])
   * @param inputExpressions
   */
 case class ST_Equals(inputExpressions: Seq[Expression])
-  extends Expression with CodegenFallback {
+  extends ST_Predicate with CodegenFallback {
   override def nullable: Boolean = false
 
   // This is a binary expression

--- a/sql/src/main/scala/org/apache/spark/sql/sedona_sql/strategy/join/BroadcastIndexJoinExec.scala
+++ b/sql/src/main/scala/org/apache/spark/sql/sedona_sql/strategy/join/BroadcastIndexJoinExec.scala
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.spark.sql.sedona_sql.strategy.join
+
+import org.apache.sedona.core.spatialRDD.SpatialRDD
+import org.apache.spark.broadcast.Broadcast
+import org.apache.spark.internal.Logging
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.{Attribute, BindReferences, Expression, UnsafeRow}
+import org.apache.spark.sql.catalyst.expressions.codegen.GenerateUnsafeRowJoiner
+import org.apache.spark.sql.catalyst.plans.physical.Partitioning
+import org.apache.spark.sql.execution.{BinaryExecNode, SparkPlan}
+import org.apache.spark.sql.execution.joins.{BuildLeft, BuildRight, BuildSide}
+import org.locationtech.jts.geom.Geometry
+import org.locationtech.jts.index.SpatialIndex
+
+import collection.JavaConverters._
+
+
+case class BroadcastIndexJoinExec(left: SparkPlan,
+                                  right: SparkPlan,
+                                  streamShape: Expression,
+                                  indexBuildSide: BuildSide,
+                                  windowJoinSide: BuildSide,
+                                  intersects: Boolean,
+                                  extraCondition: Option[Expression] = None)
+  extends BinaryExecNode
+    with TraitJoinQueryBase
+    with Logging {
+
+  override def output: Seq[Attribute] = left.output ++ right.output
+
+  private val (streamed, broadcast) = indexBuildSide match {
+    case BuildLeft => (right, left.asInstanceOf[SpatialIndexExec])
+    case BuildRight => (left, right.asInstanceOf[SpatialIndexExec])
+  }
+
+  override def outputPartitioning: Partitioning = streamed.outputPartitioning
+
+  private def windowBroadcastJoin(index: Broadcast[SpatialIndex], spatialRdd: SpatialRDD[Geometry]): RDD[(Geometry, Geometry)] = {
+    spatialRdd.getRawSpatialRDD.rdd.flatMap { row =>
+      val candidates = index.value.query(row.getEnvelopeInternal).iterator.asScala.asInstanceOf[Iterator[Geometry]]
+      candidates
+        .filter(candidate => if (intersects) candidate.intersects(row) else candidate.covers(row))
+        .map(candidate => (candidate, row))
+    }
+  }
+
+  private def objectBroadcastJoin(index: Broadcast[SpatialIndex], spatialRdd: SpatialRDD[Geometry]): RDD[(Geometry, Geometry)] = {
+    spatialRdd.getRawSpatialRDD.rdd.flatMap { row =>
+      val candidates = index.value.query(row.getEnvelopeInternal).iterator.asScala.asInstanceOf[Iterator[Geometry]]
+      candidates
+        .filter(candidate => if (intersects) row.intersects(candidate) else row.covers(candidate))
+        .map(candidate => (row, candidate))
+    }
+  }
+
+  override protected def doExecute(): RDD[InternalRow] = {
+    val boundStreamShape = BindReferences.bindReference(streamShape, streamed.output)
+    val streamResultsRaw = streamed.execute().asInstanceOf[RDD[UnsafeRow]]
+    val streamShapes = toSpatialRdd(streamResultsRaw, boundStreamShape)
+
+    val broadcastIndex = broadcast.executeBroadcast[SpatialIndex]()
+
+    val pairs = (indexBuildSide, windowJoinSide) match {
+      case (BuildLeft, BuildLeft) => windowBroadcastJoin(broadcastIndex, streamShapes)
+      case (BuildLeft, BuildRight) => objectBroadcastJoin(broadcastIndex, streamShapes).map { case (left, right) => (right, left) }
+      case (BuildRight, BuildLeft) => objectBroadcastJoin(broadcastIndex, streamShapes)
+      case (BuildRight, BuildRight) => windowBroadcastJoin(broadcastIndex, streamShapes).map { case (left, right) => (right, left) }
+    }
+
+    pairs.mapPartitions { iter =>
+      val joiner = GenerateUnsafeRowJoiner.create(left.schema, right.schema)
+      iter.map {
+        case (l, r) =>
+          val leftRow = l.getUserData.asInstanceOf[UnsafeRow]
+          val rightRow = r.getUserData.asInstanceOf[UnsafeRow]
+          joiner.join(leftRow, rightRow)
+      }
+    }
+  }
+}

--- a/sql/src/main/scala/org/apache/spark/sql/sedona_sql/strategy/join/BroadcastIndexJoinExec.scala
+++ b/sql/src/main/scala/org/apache/spark/sql/sedona_sql/strategy/join/BroadcastIndexJoinExec.scala
@@ -50,8 +50,8 @@ case class BroadcastIndexJoinExec(left: SparkPlan,
   // Using lazy val to avoid serialization
   @transient private lazy val boundCondition: (InternalRow => Boolean) = extraCondition match {
     case Some(condition) =>
-      Predicate.create(extraCondition.get, output).eval _ // SPARK3 anchor
-//      newPredicate(extraCondition.get, output).eval _ // SPARK2 anchor
+      Predicate.create(condition, output).eval _ // SPARK3 anchor
+//      newPredicate(condition, output).eval _ // SPARK2 anchor
     case None =>
       (r: InternalRow) => true
   }

--- a/sql/src/main/scala/org/apache/spark/sql/sedona_sql/strategy/join/DistanceJoinExec.scala
+++ b/sql/src/main/scala/org/apache/spark/sql/sedona_sql/strategy/join/DistanceJoinExec.scala
@@ -48,7 +48,7 @@ case class DistanceJoinExec(left: SparkPlan,
                                  buildExpr: Expression,
                                  streamedRdd: RDD[UnsafeRow],
                                  streamedExpr: Expression): (SpatialRDD[Geometry], SpatialRDD[Geometry]) =
-    (toCircleRDD(buildRdd, buildExpr), toSpatialRdd(streamedRdd, streamedExpr))
+    (toCircleRDD(buildRdd, buildExpr), toSpatialRDD(streamedRdd, streamedExpr))
 
   private def toCircleRDD(rdd: RDD[UnsafeRow], shapeExpression: Expression): SpatialRDD[Geometry] = {
     val spatialRdd = new SpatialRDD[Geometry]

--- a/sql/src/main/scala/org/apache/spark/sql/sedona_sql/strategy/join/JoinQueryDetector.scala
+++ b/sql/src/main/scala/org/apache/spark/sql/sedona_sql/strategy/join/JoinQueryDetector.scala
@@ -222,11 +222,11 @@ class JoinQueryDetector(sparkSession: SparkSession) extends Strategy {
           case (BuildLeft, false) => // Broadcast the left side, windows on the left
             (SpatialIndexExec(planLater(left), a, indexType, radius), planLater(right), b, BuildLeft)
           case (BuildLeft, true) => // Broadcast the left side, objects on the left
-            (SpatialIndexExec(planLater(left), b, indexType, radius), planLater(right), a, BuildRight)
+            (SpatialIndexExec(planLater(left), b, indexType), planLater(right), a, BuildRight)
           case (BuildRight, false) => // Broadcast the right side, windows on the left
             (planLater(left), SpatialIndexExec(planLater(right), b, indexType), a, BuildLeft)
           case (BuildRight, true) => // Broadcast the right side, objects on the left
-            (planLater(left), SpatialIndexExec(planLater(right), a, indexType), b, BuildRight)
+            (planLater(left), SpatialIndexExec(planLater(right), a, indexType, radius), b, BuildRight)
         }
         BroadcastIndexJoinExec(leftPlan, rightPlan, streamShape, broadcastSide, windowSide, intersects, extraCondition, radius) :: Nil
       case None =>

--- a/sql/src/main/scala/org/apache/spark/sql/sedona_sql/strategy/join/SpatialIndexExec.scala
+++ b/sql/src/main/scala/org/apache/spark/sql/sedona_sql/strategy/join/SpatialIndexExec.scala
@@ -26,7 +26,8 @@ import org.apache.spark.internal.Logging
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{Attribute, BindReferences, Expression, UnsafeRow}
-import org.apache.spark.sql.execution.{SparkPlan, UnaryExecNode}
+import org.apache.spark.sql.execution.SparkPlan
+import org.apache.spark.sql.execution.exchange.Exchange
 
 
 
@@ -34,7 +35,7 @@ case class SpatialIndexExec(child: SparkPlan,
                             shape: Expression,
                             indexType: IndexType,
                             radius: Option[Expression] = None)
-  extends UnaryExecNode
+  extends Exchange
     with TraitJoinQueryBase
     with Logging {
 

--- a/sql/src/main/scala/org/apache/spark/sql/sedona_sql/strategy/join/SpatialIndexExec.scala
+++ b/sql/src/main/scala/org/apache/spark/sql/sedona_sql/strategy/join/SpatialIndexExec.scala
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.spark.sql.sedona_sql.strategy.join
+
+import scala.collection.JavaConverters._
+
+import org.apache.sedona.core.enums.IndexType
+import org.apache.spark.broadcast.Broadcast
+import org.apache.spark.internal.Logging
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.{Attribute, BindReferences, Expression, UnsafeRow}
+import org.apache.spark.sql.execution.{SparkPlan, UnaryExecNode}
+
+
+
+case class SpatialIndexExec(child: SparkPlan,
+                            shape: Expression,
+                            indexType: IndexType)
+  extends UnaryExecNode
+    with TraitJoinQueryBase
+    with Logging {
+
+  override def output: Seq[Attribute] = child.output
+  
+  override protected def doExecute(): RDD[InternalRow] = {
+    throw new UnsupportedOperationException(
+      "SpatialIndex does not support the execute() code path.")
+  }
+
+  override protected[sql] def doExecuteBroadcast[T](): Broadcast[T] = {
+    val boundShape = BindReferences.bindReference(shape, child.output)
+
+    val resultRaw = child.execute().asInstanceOf[RDD[UnsafeRow]]
+
+    val spatialRDD = toSpatialRdd(resultRaw.coalesce(1), boundShape)
+
+    spatialRDD.buildIndex(indexType, false)
+    sparkContext.broadcast(spatialRDD.indexedRawRDD.take(1).asScala.head).asInstanceOf[Broadcast[T]]
+  }
+}

--- a/sql/src/main/scala/org/apache/spark/sql/sedona_sql/strategy/join/TraitJoinQueryBase.scala
+++ b/sql/src/main/scala/org/apache/spark/sql/sedona_sql/strategy/join/TraitJoinQueryBase.scala
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.spark.sql.sedona_sql.strategy.join
+
+import org.apache.sedona.core.spatialRDD.SpatialRDD
+import org.apache.sedona.core.utils.SedonaConf
+import org.apache.sedona.sql.utils.GeometrySerializer
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.catalyst.expressions.{Expression, UnsafeRow}
+import org.apache.spark.sql.catalyst.util.ArrayData
+import org.apache.spark.sql.execution.SparkPlan
+import org.locationtech.jts.geom.Geometry
+
+trait TraitJoinQueryBase {
+  self: SparkPlan =>
+
+  def toSpatialRddPair(buildRdd: RDD[UnsafeRow],
+                       buildExpr: Expression,
+                       streamedRdd: RDD[UnsafeRow],
+                       streamedExpr: Expression): (SpatialRDD[Geometry], SpatialRDD[Geometry]) =
+    (toSpatialRdd(buildRdd, buildExpr), toSpatialRdd(streamedRdd, streamedExpr))
+
+  protected def toSpatialRdd(rdd: RDD[UnsafeRow],
+                             shapeExpression: Expression): SpatialRDD[Geometry] = {
+
+    val spatialRdd = new SpatialRDD[Geometry]
+    spatialRdd.setRawSpatialRDD(
+      rdd
+        .map { x => {
+          val shape = GeometrySerializer.deserialize(shapeExpression.eval(x).asInstanceOf[ArrayData])
+          //logInfo(shape.toString)
+          shape.setUserData(x.copy)
+          shape
+        }
+        }
+        .toJavaRDD())
+    spatialRdd
+  }
+
+  def doSpatialPartitioning(dominantShapes: SpatialRDD[Geometry], followerShapes: SpatialRDD[Geometry],
+                            numPartitions: Integer, sedonaConf: SedonaConf): Unit = {
+    dominantShapes.spatialPartitioning(sedonaConf.getJoinGridType, numPartitions)
+    followerShapes.spatialPartitioning(dominantShapes.getPartitioner)
+  }
+}

--- a/sql/src/main/scala/org/apache/spark/sql/sedona_sql/strategy/join/TraitJoinQueryExec.scala
+++ b/sql/src/main/scala/org/apache/spark/sql/sedona_sql/strategy/join/TraitJoinQueryExec.scala
@@ -21,25 +21,21 @@ package org.apache.spark.sql.sedona_sql.strategy.join
 import org.apache.sedona.core.enums.JoinSparitionDominantSide
 import org.apache.sedona.core.spatialOperator.JoinQuery
 import org.apache.sedona.core.spatialOperator.JoinQuery.JoinParams
-import org.apache.sedona.core.spatialRDD.SpatialRDD
 import org.apache.sedona.core.utils.SedonaConf
-import org.apache.sedona.sql.utils.GeometrySerializer
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.catalyst.expressions.codegen.GenerateUnsafeRowJoiner
 import org.apache.spark.sql.catalyst.expressions.{Attribute, BindReferences, Expression, Predicate, UnsafeRow}
-import org.apache.spark.sql.catalyst.util.ArrayData
+import org.apache.spark.sql.catalyst.expressions.codegen.GenerateUnsafeRowJoiner
 import org.apache.spark.sql.execution.SparkPlan
-import org.locationtech.jts.geom.Geometry
 
-trait TraitJoinQueryExec {
+trait TraitJoinQueryExec extends TraitJoinQueryBase {
   self: SparkPlan =>
 
   // Using lazy val to avoid serialization
   @transient private lazy val boundCondition: (InternalRow => Boolean) = {
     if (extraCondition.isDefined) {
-Predicate.create(extraCondition.get, left.output ++ right.output).eval _ // SPARK3 anchor
-//newPredicate(extraCondition.get, left.output ++ right.output).eval _ // SPARK2 anchor
+      Predicate.create(extraCondition.get, left.output ++ right.output).eval _ // SPARK3 anchor
+//      newPredicate(extraCondition.get, left.output ++ right.output).eval _ // SPARK2 anchor
     } else { (r: InternalRow) =>
       true
     }
@@ -134,8 +130,8 @@ Predicate.create(extraCondition.get, left.output ++ right.output).eval _ // SPAR
     matches.rdd.mapPartitions { iter =>
       val filtered =
         if (extraCondition.isDefined) {
-val boundCondition = Predicate.create(extraCondition.get, left.output ++ right.output) // SPARK3 anchor
-//val boundCondition = newPredicate(extraCondition.get, left.output ++ right.output) // SPARK2 anchor
+          val boundCondition = Predicate.create(extraCondition.get, left.output ++ right.output) // SPARK3 anchor
+//          val boundCondition = newPredicate(extraCondition.get, left.output ++ right.output) // SPARK2 anchor
           iter.filter {
             case (l, r) =>
               val leftRow = l.getUserData.asInstanceOf[UnsafeRow]
@@ -155,35 +151,6 @@ val boundCondition = Predicate.create(extraCondition.get, left.output ++ right.o
           joiner.join(leftRow, rightRow)
       }
     }
-  }
-
-  def toSpatialRddPair(buildRdd: RDD[UnsafeRow],
-                       buildExpr: Expression,
-                       streamedRdd: RDD[UnsafeRow],
-                       streamedExpr: Expression): (SpatialRDD[Geometry], SpatialRDD[Geometry]) =
-    (toSpatialRdd(buildRdd, buildExpr), toSpatialRdd(streamedRdd, streamedExpr))
-
-  protected def toSpatialRdd(rdd: RDD[UnsafeRow],
-                             shapeExpression: Expression): SpatialRDD[Geometry] = {
-
-    val spatialRdd = new SpatialRDD[Geometry]
-    spatialRdd.setRawSpatialRDD(
-      rdd
-        .map { x => {
-          val shape = GeometrySerializer.deserialize(shapeExpression.eval(x).asInstanceOf[ArrayData])
-          //logInfo(shape.toString)
-          shape.setUserData(x.copy)
-          shape
-        }
-        }
-        .toJavaRDD())
-    spatialRdd
-  }
-
-  def doSpatialPartitioning(dominantShapes: SpatialRDD[Geometry], followerShapes: SpatialRDD[Geometry],
-                            numPartitions: Integer, sedonaConf: SedonaConf): Unit = {
-    dominantShapes.spatialPartitioning(sedonaConf.getJoinGridType, numPartitions)
-    followerShapes.spatialPartitioning(dominantShapes.getPartitioner)
   }
 
   def joinPartitionNumOptimizer(dominantSidePartNum: Int, followerSidePartNum: Int, dominantSideCount: Long): Int = {

--- a/sql/src/main/scala/org/apache/spark/sql/sedona_sql/strategy/join/enums.scala
+++ b/sql/src/main/scala/org/apache/spark/sql/sedona_sql/strategy/join/enums.scala
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.spark.sql.sedona_sql.strategy.join
+
+sealed trait JoinSide
+
+case object LeftSide extends JoinSide
+case object RightSide extends JoinSide

--- a/sql/src/test/scala/org/apache/sedona/sql/BroadcastIndexJoinSuite.scala
+++ b/sql/src/test/scala/org/apache/sedona/sql/BroadcastIndexJoinSuite.scala
@@ -19,6 +19,7 @@
 
 package org.apache.sedona.sql
 
+import org.apache.spark.sql.sedona_sql.strategy.join.BroadcastIndexJoinExec
 import org.apache.spark.sql.functions._
 
 class BroadcastIndexJoinSuite extends TestBaseScala {
@@ -26,39 +27,35 @@ class BroadcastIndexJoinSuite extends TestBaseScala {
   describe("Sedona-SQL Broadcast Index Join Test") {
 
     it("Passed Correct partitioning for broadcast join for ST_Polygon and ST_Point") {
-      var polygonCsvDf = loadCsv(csvPolygonInputLocation)
-      var polygonDf = polygonCsvDf.selectExpr("ST_PolygonFromEnvelope(cast(_c0 as Decimal(24,20)),cast(_c1 as Decimal(24,20)), cast(_c2 as Decimal(24,20)), cast(_c3 as Decimal(24,20))) as polygonshape")
-      polygonDf = polygonDf.repartition(3)
-
-      var pointCsvDf = loadCsv(csvPointInputLocation)
-      var pointDf = pointCsvDf.selectExpr("ST_Point(cast(_c0 as Decimal(24,20)),cast(_c1 as Decimal(24,20))) as pointshape")
-      pointDf = pointDf.repartition(5)
+      val polygonDf = buildPolygonDf.repartition(3)
+      val pointDf = buildPointDf.repartition(5)
 
       var broadcastJoinDf = pointDf.alias("pointDf").join(polygonDf.alias("polygonDf").hint("broadcast"), expr("ST_Contains(polygonDf.polygonshape, pointDf.pointshape)"))
+      assert(broadcastJoinDf.queryExecution.sparkPlan.collect{ case p: BroadcastIndexJoinExec => p }.size === 1)
       assert(broadcastJoinDf.rdd.getNumPartitions == pointDf.rdd.getNumPartitions)
       assert(broadcastJoinDf.count() == 1000)
 
       broadcastJoinDf = polygonDf.alias("polygonDf").hint("broadcast").join(pointDf.alias("pointDf"), expr("ST_Contains(polygonDf.polygonshape, pointDf.pointshape)"))
+      assert(broadcastJoinDf.queryExecution.sparkPlan.collect{ case p: BroadcastIndexJoinExec => p }.size === 1)
       assert(broadcastJoinDf.rdd.getNumPartitions == pointDf.rdd.getNumPartitions)
       assert(broadcastJoinDf.count() == 1000)
 
       broadcastJoinDf = pointDf.alias("pointDf").hint("broadcast").join(polygonDf.alias("polygonDf"), expr("ST_Contains(polygonDf.polygonshape, pointDf.pointshape)"))
+      assert(broadcastJoinDf.queryExecution.sparkPlan.collect{ case p: BroadcastIndexJoinExec => p }.size === 1)
       assert(broadcastJoinDf.rdd.getNumPartitions == polygonDf.rdd.getNumPartitions)
       assert(broadcastJoinDf.count() == 1000)
 
       broadcastJoinDf = polygonDf.alias("polygonDf").join(pointDf.alias("pointDf").hint("broadcast"), expr("ST_Contains(polygonDf.polygonshape, pointDf.pointshape)"))
+      assert(broadcastJoinDf.queryExecution.sparkPlan.collect{ case p: BroadcastIndexJoinExec => p }.size === 1)
       assert(broadcastJoinDf.rdd.getNumPartitions == polygonDf.rdd.getNumPartitions)
       assert(broadcastJoinDf.count() == 1000)
     }
 
-    it("Passed Can access attributes of both sides") {
-      var polygonCsvDf = loadCsv(csvPolygonInputLocation)
-      var polygonDf = polygonCsvDf.select(expr("ST_PolygonFromEnvelope(cast(_c0 as Decimal(24,20)),cast(_c1 as Decimal(24,20)), cast(_c2 as Decimal(24,20)), cast(_c3 as Decimal(24,20)))").alias("polygonshape"), lit(1).alias("window_extra"))
-
-      var pointCsvDf = loadCsv(csvPointInputLocation)
-      var pointDf = pointCsvDf.select(expr("ST_Point(cast(_c0 as Decimal(24,20)),cast(_c1 as Decimal(24,20)))").alias("pointshape"), lit(1).alias("object_extra"))
-
-      var broadcastJoinDf = polygonDf.alias("polygonDf").join(broadcast(pointDf.alias("pointDf")), expr("ST_Contains(polygonDf.polygonshape, pointDf.pointshape)"))
+    it("Passed Can access attributes of both sides of broadcast join") {
+      val polygonDf = buildPolygonDf.withColumn("window_extra", lit(1))
+      val pointDf = buildPointDf.withColumn("object_extra", lit(1))
+      
+      var broadcastJoinDf = polygonDf.alias("polygonDf").join(broadcast(pointDf).alias("pointDf"), expr("ST_Contains(polygonDf.polygonshape, pointDf.pointshape)"))
       assert(broadcastJoinDf.select(sum("object_extra")).collect().head(0) == 1000)
       assert(broadcastJoinDf.select(sum("window_extra")).collect().head(0) == 1000)
 
@@ -73,6 +70,47 @@ class BroadcastIndexJoinSuite extends TestBaseScala {
       broadcastJoinDf = pointDf.alias("pointDf").join(broadcast(polygonDf).alias("polygonDf"), expr("ST_Contains(polygonDf.polygonshape, pointDf.pointshape)"))
       assert(broadcastJoinDf.select(sum("object_extra")).collect().head(0) == 1000)
       assert(broadcastJoinDf.select(sum("window_extra")).collect().head(0) == 1000)
+    }
+
+    it("Passed Handles extra conditions on a broadcast join") {
+      val polygonDf = buildPolygonDf.withColumn("window_extra", expr("ST_X(element_at(ST_DumpPoints(polygonshape), 1))"))
+      val pointDf = buildPointDf.withColumn("object_extra", expr("ST_X(pointshape)"))
+
+      var broadcastJoinDf = pointDf
+        .alias("pointDf")
+        .join(
+          polygonDf.alias("polygonDf").hint("broadcast"),
+          expr("ST_Contains(polygonshape, pointshape) AND window_extra <= object_extra")
+        )
+
+      assert(broadcastJoinDf.queryExecution.sparkPlan.collect{ case p: BroadcastIndexJoinExec => p }.size === 1)
+      assert(broadcastJoinDf.count() == 1000)
+    }
+
+    it("Passed ST_Distance <= radius in a broadcast join") {
+      var pointDf1 = buildPointDf
+      var pointDf2 = buildPointDf
+
+      var distanceJoinDf = pointDf1.alias("pointDf1").join(broadcast(pointDf2).alias("pointDf2"), expr("ST_Distance(pointDf1.pointshape, pointDf2.pointshape) <= 2"))
+      assert(distanceJoinDf.queryExecution.sparkPlan.collect{ case p: BroadcastIndexJoinExec => p }.size === 1)
+      assert(distanceJoinDf.count() == 2998)
+
+      distanceJoinDf = broadcast(pointDf1).alias("pointDf1").join(pointDf2.alias("pointDf2"), expr("ST_Distance(pointDf1.pointshape, pointDf2.pointshape) <= 2"))
+      assert(distanceJoinDf.queryExecution.sparkPlan.collect{ case p: BroadcastIndexJoinExec => p }.size === 1)
+      assert(distanceJoinDf.count() == 2998)
+    }
+
+    it("Passed ST_Distance < radius in a broadcast join") {
+      var pointDf1 = buildPointDf
+      var pointDf2 = buildPointDf
+
+      var distanceJoinDf = pointDf1.alias("pointDf1").join(broadcast(pointDf2).alias("pointDf2"), expr("ST_Distance(pointDf1.pointshape, pointDf2.pointshape) < 2"))
+      assert(distanceJoinDf.queryExecution.sparkPlan.collect{ case p: BroadcastIndexJoinExec => p }.size === 1)
+      assert(distanceJoinDf.count() == 2998)
+
+      distanceJoinDf = broadcast(pointDf1).alias("pointDf1").join(pointDf2.alias("pointDf2"), expr("ST_Distance(pointDf1.pointshape, pointDf2.pointshape) < 2"))
+      assert(distanceJoinDf.queryExecution.sparkPlan.collect{ case p: BroadcastIndexJoinExec => p }.size === 1)
+      assert(distanceJoinDf.count() == 2998)
     }
   }
 }

--- a/sql/src/test/scala/org/apache/sedona/sql/BroadcastIndexJoinSuite.scala
+++ b/sql/src/test/scala/org/apache/sedona/sql/BroadcastIndexJoinSuite.scala
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.sedona.sql
+
+import org.apache.spark.sql.functions._
+
+class BroadcastIndexJoinSuite extends TestBaseScala {
+
+  describe("Sedona-SQL Broadcast Index Join Test") {
+
+    it("Passed Correct partitioning for broadcast join for ST_Polygon and ST_Point") {
+      var polygonCsvDf = loadCsv(csvPolygonInputLocation)
+      var polygonDf = polygonCsvDf.selectExpr("ST_PolygonFromEnvelope(cast(_c0 as Decimal(24,20)),cast(_c1 as Decimal(24,20)), cast(_c2 as Decimal(24,20)), cast(_c3 as Decimal(24,20))) as polygonshape")
+      polygonDf = polygonDf.repartition(3)
+
+      var pointCsvDf = loadCsv(csvPointInputLocation)
+      var pointDf = pointCsvDf.selectExpr("ST_Point(cast(_c0 as Decimal(24,20)),cast(_c1 as Decimal(24,20))) as pointshape")
+      pointDf = pointDf.repartition(5)
+
+      var broadcastJoinDf = pointDf.alias("pointDf").join(polygonDf.alias("polygonDf").hint("broadcast"), expr("ST_Contains(polygonDf.polygonshape, pointDf.pointshape)"))
+      assert(broadcastJoinDf.rdd.getNumPartitions == pointDf.rdd.getNumPartitions)
+      assert(broadcastJoinDf.count() == 1000)
+
+      broadcastJoinDf = polygonDf.alias("polygonDf").hint("broadcast").join(pointDf.alias("pointDf"), expr("ST_Contains(polygonDf.polygonshape, pointDf.pointshape)"))
+      assert(broadcastJoinDf.rdd.getNumPartitions == pointDf.rdd.getNumPartitions)
+      assert(broadcastJoinDf.count() == 1000)
+
+      broadcastJoinDf = pointDf.alias("pointDf").hint("broadcast").join(polygonDf.alias("polygonDf"), expr("ST_Contains(polygonDf.polygonshape, pointDf.pointshape)"))
+      assert(broadcastJoinDf.rdd.getNumPartitions == polygonDf.rdd.getNumPartitions)
+      assert(broadcastJoinDf.count() == 1000)
+
+      broadcastJoinDf = polygonDf.alias("polygonDf").join(pointDf.alias("pointDf").hint("broadcast"), expr("ST_Contains(polygonDf.polygonshape, pointDf.pointshape)"))
+      assert(broadcastJoinDf.rdd.getNumPartitions == polygonDf.rdd.getNumPartitions)
+      assert(broadcastJoinDf.count() == 1000)
+    }
+
+    it("Passed Can access attributes of both sides") {
+      var polygonCsvDf = loadCsv(csvPolygonInputLocation)
+      var polygonDf = polygonCsvDf.select(expr("ST_PolygonFromEnvelope(cast(_c0 as Decimal(24,20)),cast(_c1 as Decimal(24,20)), cast(_c2 as Decimal(24,20)), cast(_c3 as Decimal(24,20)))").alias("polygonshape"), lit(1).alias("window_extra"))
+
+      var pointCsvDf = loadCsv(csvPointInputLocation)
+      var pointDf = pointCsvDf.select(expr("ST_Point(cast(_c0 as Decimal(24,20)),cast(_c1 as Decimal(24,20)))").alias("pointshape"), lit(1).alias("object_extra"))
+
+      var broadcastJoinDf = polygonDf.alias("polygonDf").join(broadcast(pointDf.alias("pointDf")), expr("ST_Contains(polygonDf.polygonshape, pointDf.pointshape)"))
+      assert(broadcastJoinDf.select(sum("object_extra")).collect().head(0) == 1000)
+      assert(broadcastJoinDf.select(sum("window_extra")).collect().head(0) == 1000)
+
+      broadcastJoinDf = broadcast(polygonDf).alias("polygonDf").join(pointDf.alias("pointDf"), expr("ST_Contains(polygonDf.polygonshape, pointDf.pointshape)"))
+      assert(broadcastJoinDf.select(sum("object_extra")).collect().head(0) == 1000)
+      assert(broadcastJoinDf.select(sum("window_extra")).collect().head(0) == 1000)
+
+      broadcastJoinDf = broadcast(pointDf).alias("pointDf").join(polygonDf.alias("polygonDf"), expr("ST_Contains(polygonDf.polygonshape, pointDf.pointshape)"))
+      assert(broadcastJoinDf.select(sum("object_extra")).collect().head(0) == 1000)
+      assert(broadcastJoinDf.select(sum("window_extra")).collect().head(0) == 1000)
+
+      broadcastJoinDf = pointDf.alias("pointDf").join(broadcast(polygonDf).alias("polygonDf"), expr("ST_Contains(polygonDf.polygonshape, pointDf.pointshape)"))
+      assert(broadcastJoinDf.select(sum("object_extra")).collect().head(0) == 1000)
+      assert(broadcastJoinDf.select(sum("window_extra")).collect().head(0) == 1000)
+    }
+  }
+}

--- a/sql/src/test/scala/org/apache/sedona/sql/TestBaseScala.scala
+++ b/sql/src/test/scala/org/apache/sedona/sql/TestBaseScala.scala
@@ -73,4 +73,7 @@ trait TestBaseScala extends FunSpec with BeforeAndAfterAll {
   def loadCsv(path: String): DataFrame = {
     sparkSession.read.format("csv").option("delimiter", ",").option("header", "false").load(path)
   }
+
+  lazy val buildPointDf = loadCsv(csvPointInputLocation).selectExpr("ST_Point(cast(_c0 as Decimal(24,20)),cast(_c1 as Decimal(24,20))) as pointshape")
+  lazy val buildPolygonDf = loadCsv(csvPolygonInputLocation).selectExpr("ST_PolygonFromEnvelope(cast(_c0 as Decimal(24,20)),cast(_c1 as Decimal(24,20)), cast(_c2 as Decimal(24,20)), cast(_c3 as Decimal(24,20))) as polygonshape")
 }

--- a/sql/src/test/scala/org/apache/sedona/sql/TestBaseScala.scala
+++ b/sql/src/test/scala/org/apache/sedona/sql/TestBaseScala.scala
@@ -22,7 +22,7 @@ import org.apache.log4j.{Level, Logger}
 import org.apache.sedona.core.serde.SedonaKryoRegistrator
 import org.apache.sedona.sql.utils.SedonaSQLRegistrator
 import org.apache.spark.serializer.KryoSerializer
-import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.{DataFrame, SparkSession}
 import org.scalatest.{BeforeAndAfterAll, FunSpec}
 
 trait TestBaseScala extends FunSpec with BeforeAndAfterAll {
@@ -39,7 +39,6 @@ trait TestBaseScala extends FunSpec with BeforeAndAfterAll {
     .getOrCreate()
 
   val resourceFolder = System.getProperty("user.dir") + "/../core/src/test/resources/"
-
   val mixedWkbGeometryInputLocation = resourceFolder + "county_small_wkb.tsv"
   val mixedWktGeometryInputLocation = resourceFolder + "county_small.tsv"
   val shapefileInputLocation = resourceFolder + "shapefiles/dbf"
@@ -69,5 +68,9 @@ trait TestBaseScala extends FunSpec with BeforeAndAfterAll {
   override def afterAll(): Unit = {
     //SedonaSQLRegistrator.dropAll(spark)
     //spark.stop
+  }
+
+  def loadCsv(path: String): DataFrame = {
+    sparkSession.read.format("csv").option("delimiter", ",").option("header", "false").load(path)
   }
 }

--- a/sql/src/test/scala/org/apache/sedona/sql/predicateJoinTestScala.scala
+++ b/sql/src/test/scala/org/apache/sedona/sql/predicateJoinTestScala.scala
@@ -21,7 +21,6 @@ package org.apache.sedona.sql
 
 import org.apache.sedona.core.utils.SedonaConf
 import org.apache.spark.sql.Row
-import org.apache.spark.sql.sedona_sql.strategy.join.JoinQueryDetector
 import org.apache.spark.sql.types._
 
 class predicateJoinTestScala extends TestBaseScala {
@@ -127,8 +126,6 @@ class predicateJoinTestScala extends TestBaseScala {
     }
 
     it("Passed ST_Distance <= radius in a join") {
-      sparkSession.experimental.extraStrategies = JoinQueryDetector :: Nil
-
       var pointCsvDF1 = sparkSession.read.format("csv").option("delimiter", ",").option("header", "false").load(csvPointInputLocation)
       pointCsvDF1.createOrReplaceTempView("pointtable")
       var pointDf1 = sparkSession.sql("select ST_Point(cast(pointtable._c0 as Decimal(24,20)),cast(pointtable._c1 as Decimal(24,20))) as pointshape1 from pointtable")
@@ -145,8 +142,6 @@ class predicateJoinTestScala extends TestBaseScala {
     }
 
     it("Passed ST_Distance < radius in a join") {
-      sparkSession.experimental.extraStrategies = JoinQueryDetector :: Nil
-
       var pointCsvDF1 = sparkSession.read.format("csv").option("delimiter", ",").option("header", "false").load(csvPointInputLocation)
       pointCsvDF1.createOrReplaceTempView("pointtable")
       var pointDf1 = sparkSession.sql("select ST_Point(cast(pointtable._c0 as Decimal(24,20)),cast(pointtable._c1 as Decimal(24,20))) as pointshape1 from pointtable")


### PR DESCRIPTION
## Is this PR related to a proposed Issue?
https://issues.apache.org/jira/browse/SEDONA-26

## What changes were proposed in this PR?
Adds SQL broadcast join support. Broadcast hints are detected in the SQL Join detector and will execute a new `BroadcastIndexJoin` plan (that uses a `SpatialIndex` child plan, mostly for nice display purposes in the query plan).

## How was this patch tested?
New UT, still need to add more

## Did this PR include necessary documentation updates?
Yes

Still have some work to do on this, but wanted to get some initial feedback on the overall approach. I opted to keep things purely in SQL land instead of trying to add more parameters to spatialJoin or add another new core package that SQL calls out to. ~Currently works for Spark 3, and it compiles in Spark 2 but the new test fails because broadcasts aren't currently detected in Spark 2.~ Figured out the Spark 2 support.

Also, I tried to better maintain the concept of left and right sides of the join, to more easily implement join types other than inner in the future. Rather than refer to the shapes as left and right where left.contains(right), I wanted to use different naming scheme. I went with window.contains(object), but very open to other ideas on how to separate the join sides versus <what>.contains(<what>).

TODOs:
- [x] Either figure out how to detect broadcast hints in Spark 2, or update the tests to only run the broadcast test on Spark 3
- [x] Add support for distance joins
- [x] Add this to the documentation somewhere
- [x] Probably add more unit tests
