### PR TITLE
Make the pom file ready to upload checksum using the resolved pom

### DIFF
--- a/core/src/test/java/org/apache/sedona/core/io/EarthdataHDFTest.java
+++ b/core/src/test/java/org/apache/sedona/core/io/EarthdataHDFTest.java
@@ -126,7 +126,7 @@ public class EarthdataHDFTest
         HDFoffset = 2;
         HDFrootGroupName = "MOD_Swath_LST";
         HDFDataVariableName = "LST";
-        urlPrefix = System.getProperty("user.dir") + "/src/test/resources/modis/";
+        urlPrefix = System.getProperty("user.dir") + "/../src/test/resources/modis/";
     }
 
     /**

--- a/core/src/test/java/org/apache/sedona/core/io/EarthdataHDFTest.java
+++ b/core/src/test/java/org/apache/sedona/core/io/EarthdataHDFTest.java
@@ -126,7 +126,7 @@ public class EarthdataHDFTest
         HDFoffset = 2;
         HDFrootGroupName = "MOD_Swath_LST";
         HDFDataVariableName = "LST";
-        urlPrefix = System.getProperty("user.dir") + "/../src/test/resources/modis/";
+        urlPrefix = System.getProperty("user.dir") + "/src/test/resources/modis/";
     }
 
     /**

--- a/pom.xml
+++ b/pom.xml
@@ -430,7 +430,7 @@
                 <executions>
                     <execution>
                         <id>resolve-my-pom</id>
-                        <phase>initialize</phase>
+                        <phase>test</phase>
                         <goals>
                             <goal>resolve-pom</goal>
                         </goals>

--- a/pom.xml
+++ b/pom.xml
@@ -430,7 +430,7 @@
                 <executions>
                     <execution>
                         <id>resolve-my-pom</id>
-                        <phase>prepare-package</phase>
+                        <phase>initialize</phase>
                         <goals>
                             <goal>resolve-pom</goal>
                         </goals>


### PR DESCRIPTION
## Is this PR related to a proposed Issue?

N/A

## What changes were proposed in this PR?

This PR is to fix an issue that occurred in the release procedure. The resolved-pom plugin was supposed to replace all pom variables with real values in the initialize phase of the Maven build lifecyle. Otherwise, the new poms will not be uploaded to Maven Central.

## How was this patch tested?

Pass all existing test cases


## Did this PR include necessary documentation updates?
