### PR TITLE
[SEDONA-29] Upgrade to Spark 3.1.1 and fix ST_Pixelize

### DIFF
--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -14,11 +14,9 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        spark: [2.4.7, 3.0.2, 3.1.1]
+        spark: [2.4.7, 3.1.1]
         scala: [2.11.8, 2.12.8]
         exclude:
-          - spark: 3.0.2
-            scala: 2.11.8
           - spark: 3.1.1
             scala: 2.11.8
 
@@ -39,11 +37,8 @@ jobs:
     - run: git submodule update --init --recursive # Checkout Git submodule if necessary
     - env:
         SPARK_VERSION: ${{ matrix.spark }}
-      run: python3 spark-version-converter.py spark${SPARK_VERSION:0:1}
-    - env:
-        SPARK_VERSION: ${{ matrix.spark }}
         SCALA_VERSION: ${{ matrix.scala }}
-      run: mvn -q clean install -Dscala=${SCALA_VERSION:0:4} -Dspark=${SPARK_VERSION:0:3}
+      run: if [ ${SPARK_VERSION:0:1} == "3" ]; then mvn -q clean install -Dscala=${SCALA_VERSION:0:4} -Dspark=3.0 ; else mvn -q clean install -Dscala=${SCALA_VERSION:0:4} -Dspark=2.4 ; fi
     - run: mkdir staging
     - run: cp core/target/sedona-*.jar staging
     - run: cp sql/target/sedona-*.jar staging

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -14,10 +14,12 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        spark: [2.4.7, 3.1.1]
+        spark: [2.4.7, 3.0.2, 3.1.1]
         scala: [2.11.8, 2.12.8]
         exclude:
           - spark: 3.1.1
+            scala: 2.11.8
+          - spark: 3.0.2
             scala: 2.11.8
 
     steps:

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -14,10 +14,12 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        spark: [2.4.7, 3.0.1]
+        spark: [2.4.7, 3.0.2, 3.1.1]
         scala: [2.11.8, 2.12.8]
         exclude:
-          - spark: 3.0.1
+          - spark: 3.0.2
+            scala: 2.11.8
+          - spark: 3.1.1
             scala: 2.11.8
 
     steps:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -15,15 +15,18 @@ jobs:
     strategy:
       matrix:
         include:
-          - spark: 3.0.1
+          - spark: 3.1.1
             scala: 2.12.8
             python: 3.7
-          - spark: 3.0.1
+          - spark: 3.1.1
             scala: 2.12.8
             python: 3.8
-          - spark: 3.0.1
+          - spark: 3.1.1
             scala: 2.12.8
             python: 3.9
+          - spark: 3.0.2
+            scala: 2.12.8
+            python: 3.7
           - spark: 2.4.7
             scala: 2.11.8
             python: 3.7

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -24,9 +24,6 @@ jobs:
           - spark: 3.1.1
             scala: 2.12.8
             python: 3.9
-          - spark: 3.0.2
-            scala: 2.12.8
-            python: 3.7
           - spark: 2.4.7
             scala: 2.11.8
             python: 3.7
@@ -48,11 +45,8 @@ jobs:
     - run: git submodule update --init --recursive # Checkout Git submodule if necessary
     - env:
         SPARK_VERSION: ${{ matrix.spark }}
-      run: python3 spark-version-converter.py spark${SPARK_VERSION:0:1}
-    - env:
-        SPARK_VERSION: ${{ matrix.spark }}
         SCALA_VERSION: ${{ matrix.scala }}
-      run: mvn -q clean install -DskipTests -Dscala=${SCALA_VERSION:0:4} -Dspark=${SPARK_VERSION:0:3} -Dgeotools
+      run: if [ ${SPARK_VERSION:0:1} == "3" ]; then mvn -q clean install -DskipTests -Dscala=${SCALA_VERSION:0:4} -Dspark=3.0 ; else mvn -q clean install -DskipTests -Dscala=${SCALA_VERSION:0:4} -Dspark=2.4 ; fi
     - env:
         SPARK_VERSION: ${{ matrix.spark }}
       run: wget https://archive.apache.org/dist/spark/spark-${SPARK_VERSION}/spark-${SPARK_VERSION}-bin-hadoop2.7.tgz

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -24,6 +24,9 @@ jobs:
           - spark: 3.1.1
             scala: 2.12.8
             python: 3.9
+          - spark: 3.0.2
+            scala: 2.12.8
+            python: 3.7
           - spark: 2.4.7
             scala: 2.11.8
             python: 3.7

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -46,7 +46,7 @@ jobs:
     - env:
         SPARK_VERSION: ${{ matrix.spark }}
         SCALA_VERSION: ${{ matrix.scala }}
-      run: if [ ${SPARK_VERSION:0:1} == "3" ]; then mvn -q clean install -DskipTests -Dscala=${SCALA_VERSION:0:4} -Dspark=3.0 ; else mvn -q clean install -DskipTests -Dscala=${SCALA_VERSION:0:4} -Dspark=2.4 ; fi
+      run: if [ ${SPARK_VERSION:0:1} == "3" ]; then mvn -q clean install -DskipTests -Dscala=${SCALA_VERSION:0:4} -Dspark=3.0 -Dgeotools ; else mvn -q clean install -DskipTests -Dscala=${SCALA_VERSION:0:4} -Dspark=2.4 -Dgeotools ; fi
     - env:
         SPARK_VERSION: ${{ matrix.spark }}
       run: wget https://archive.apache.org/dist/spark/spark-${SPARK_VERSION}/spark-${SPARK_VERSION}-bin-hadoop2.7.tgz

--- a/docs/api/viz/sql.md
+++ b/docs/api/viz/sql.md
@@ -20,7 +20,7 @@ SedonaVizRegistrator.registerAll(sparkSession)
 
 ### ST_Pixelize
 
-Introduction: Return a pixel for a given resolution
+Introduction: Convert a geometry to an array of pixels given a resolution
 
 Format: `ST_Pixelize (A:geometry, ResolutionX:int, ResolutionY:int, Boundary:geometry)`
 

--- a/docs/download/overview.md
+++ b/docs/download/overview.md
@@ -1,21 +1,21 @@
 ## Supported platforms
 
-Sedona supports Spark 2.4 and 3.0. Sedona Scala/Java/Python also work with Spark 2.3 but we have no plan to officially support it.
+Sedona supports Spark 2.4 and 3.0, Python 3.7 - 3.9. Sedona Scala/Java/Python also work with Spark 2.3, Python 3.6 but we have no plan to officially support it.
 
 Sedona is compiled and tested on Java 1.8 and Scala 2.11/2.12:
 
-|             | Spark 2.4 | Spark 3.0 |
-|:-----------:| :---------:|:---------:|
-| Scala 2.11  |  ✅  |  not tested  |
-| Scala 2.12 | ✅  |  ✅  |
+|             | Spark 2.4 | Spark 3.0 | Spark 3.1 |
+|:-----------:| :---------:|:---------:|:---------:|
+| Scala 2.11  |  ✅  |  not tested  | not tested |
+| Scala 2.12 | ✅  |  ✅  |  ✅  |
 
 Sedona Python is tested on the following Python and Spark verisons:
 
-|             | Spark 2.4 (Scala 2.11) | Spark 3.0 (Scala 2.12)|
-|:-----------:|:---------:|:---------:|
-| Python 3.7  |  ✅  |  ✅  |
-| Python 3.8 | not tested  |  ✅  |
-| Python 3.9 | not tested  |  ✅  |
+|             | Spark 2.4 (Scala 2.11) | Spark 3.0 (Scala 2.12)|Spark 3.1 (Scala 2.12)|
+|:-----------:|:---------:|:---------:|:---------:|
+| Python 3.7  |  ✅  |  ✅  |✅  |
+| Python 3.8 | not tested  |  not tested  |  ✅  |
+| Python 3.9 | not tested  |  not tested  |  ✅  |
 
 
 ## Direct download

--- a/docs/download/overview.md
+++ b/docs/download/overview.md
@@ -4,18 +4,18 @@ Sedona supports Spark 2.4 and 3.0, Python 3.7 - 3.9. Sedona Scala/Java/Python al
 
 Sedona is compiled and tested on Java 1.8 and Scala 2.11/2.12:
 
-|             | Spark 2.4 | Spark 3.0 | Spark 3.1 |
-|:-----------:| :---------:|:---------:|:---------:|
-| Scala 2.11  |  ✅  |  not tested  | not tested |
-| Scala 2.12 | ✅  |  ✅  |  ✅  |
+|             | Spark 2.4 | Spark 3.0+ |
+|:-----------:| :---------:|:---------:|
+| Scala 2.11  |  ✅  |  not tested  |
+| Scala 2.12 | ✅  |  ✅  |
 
 Sedona Python is tested on the following Python and Spark verisons:
 
-|             | Spark 2.4 (Scala 2.11) | Spark 3.0 (Scala 2.12)|Spark 3.1 (Scala 2.12)|
-|:-----------:|:---------:|:---------:|:---------:|
-| Python 3.7  |  ✅  |  ✅  |✅  |
-| Python 3.8 | not tested  |  not tested  |  ✅  |
-| Python 3.9 | not tested  |  not tested  |  ✅  |
+|             | Spark 2.4 (Scala 2.11) | Spark 3.0+ (Scala 2.12)|
+|:-----------:|:---------:|:---------:|
+| Python 3.7  |  ✅  |  ✅  |
+| Python 3.8 | not tested  |  ✅  |
+| Python 3.9 | not tested  |  ✅  |
 
 
 ## Direct download

--- a/docs/tutorial/viz.md
+++ b/docs/tutorial/viz.md
@@ -87,12 +87,22 @@ CREATE OR REPLACE TEMP VIEW boundtable AS
 SELECT ST_Envelope_Aggr(shape) as bound FROM pointtable
 ```
 
-Then use ST_Pixelize to conver them to pixels.
+Then use ST_Pixelize to convert them to pixels.
+
+This example is for Sedona before v1.0.1. ST_Pixelize extends Generator so it can directly flatten the array without the **explode** function.
 
 ```sql
 CREATE OR REPLACE TEMP VIEW pixels AS
 SELECT pixel, shape FROM pointtable
 LATERAL VIEW ST_Pixelize(ST_Transform(shape, 'epsg:4326','epsg:3857'), 256, 256, (SELECT ST_Transform(bound, 'epsg:4326','epsg:3857') FROM boundtable)) AS pixel
+```
+
+This example is for Sedona on and after v1.0.1. ST_Pixelize returns an array of pixels. You need to use **explode** to flatten it.
+
+```sql
+CREATE OR REPLACE TEMP VIEW pixels AS
+SELECT pixel, shape FROM pointtable
+LATERAL VIEW explode(ST_Pixelize(ST_Transform(shape, 'epsg:4326','epsg:3857'), 256, 256, (SELECT ST_Transform(bound, 'epsg:4326','epsg:3857') FROM boundtable))) AS pixel
 ```
 
 This will give you a 256*256 resolution image after you run ST_Render at the end of this tutorial.

--- a/examples/rdd-colocation-mining/build.sbt
+++ b/examples/rdd-colocation-mining/build.sbt
@@ -14,7 +14,7 @@ lazy val root = (project in file(".")).
     publishMavenStyle := true
   )
 
-val SparkVersion = "3.0.1"
+val SparkVersion = "3.1.1"
 
 val SparkCompatibleVersion = "3.0"
 

--- a/examples/sql/build.sbt
+++ b/examples/sql/build.sbt
@@ -14,7 +14,7 @@ lazy val root = (project in file(".")).
     publishMavenStyle := true
   )
 
-val SparkVersion = "3.0.1"
+val SparkVersion = "3.1.1"
 
 val SparkCompatibleVersion = "3.0"
 

--- a/examples/viz/build.sbt
+++ b/examples/viz/build.sbt
@@ -15,7 +15,7 @@ lazy val root = (project in file(".")).
     publishMavenStyle := true
   )
 
-val SparkVersion = "3.0.1"
+val SparkVersion = "3.1.1"
 
 val SparkCompatibleVersion = "3.0"
 

--- a/examples/viz/src/main/scala/ScalaExample.scala
+++ b/examples/viz/src/main/scala/ScalaExample.scala
@@ -45,6 +45,7 @@ object ScalaExample extends App{
 
 	val sparkConf = new SparkConf().setAppName("SedonaVizDemo").set("spark.serializer", classOf[KryoSerializer].getName)
 		.set("spark.kryo.registrator", classOf[SedonaVizKryoRegistrator].getName)
+		.set("spark.sql.view.maxNestedViewDepth", "300")
 		.setMaster("local[*]")
 	val sparkContext = new SparkContext(sparkConf)
 

--- a/examples/viz/src/main/scala/ScalaExample.scala
+++ b/examples/viz/src/main/scala/ScalaExample.scala
@@ -45,7 +45,6 @@ object ScalaExample extends App{
 
 	val sparkConf = new SparkConf().setAppName("SedonaVizDemo").set("spark.serializer", classOf[KryoSerializer].getName)
 		.set("spark.kryo.registrator", classOf[SedonaVizKryoRegistrator].getName)
-		.set("spark.sql.view.maxNestedViewDepth", "300")
 		.setMaster("local[*]")
 	val sparkContext = new SparkContext(sparkConf)
 
@@ -187,20 +186,8 @@ object ScalaExample extends App{
 		SedonaSQLRegistrator.registerAll(spark)
 		SedonaVizRegistrator.registerAll(spark)
 		var pointDf = spark.read.format("csv").option("delimiter", ",").option("header", "false").load(PointInputLocation)
-		pointDf.createOrReplaceTempView("pointtable")
-		spark.sql(
-			"""
-				|CREATE OR REPLACE TEMP VIEW pointtable AS
-				|SELECT ST_Point(cast(pointtable._c0 as Decimal(24,20)),cast(pointtable._c1 as Decimal(24,20))) as shape
-				|FROM pointtable
-			""".stripMargin)
-		spark.sql(
-			"""
-				|CREATE OR REPLACE TEMP VIEW pointtable AS
-				|SELECT *
-				|FROM pointtable
-				|WHERE ST_Contains(ST_PolygonFromEnvelope(-126.790180,24.863836,-64.630926,50.000),shape)
-			""".stripMargin)
+		pointDf.selectExpr("ST_Point(cast(_c0 as Decimal(24,20)),cast(_c1 as Decimal(24,20))) as shape")
+			.filter("ST_Contains(ST_PolygonFromEnvelope(-126.790180,24.863836,-64.630926,50.000),shape)").createOrReplaceTempView("pointtable")
 		spark.sql(
 			"""
 				|CREATE OR REPLACE TEMP VIEW pixels AS

--- a/pom.xml
+++ b/pom.xml
@@ -495,7 +495,7 @@
                 <activeByDefault>true</activeByDefault>
             </activation>
             <properties>
-                <spark.version>3.0.1</spark.version>
+                <spark.version>3.1.1</spark.version>
                 <spark.compat.version>3.0</spark.compat.version>
                 <spark.converter.version>spark3</spark.converter.version>
                 <jackson.version>2.10.0</jackson.version>

--- a/python-adapter/pom.xml
+++ b/python-adapter/pom.xml
@@ -59,41 +59,15 @@
         </dependency>
         <!--for CRS transformation-->
         <dependency>
-            <groupId>org.geotools</groupId>
-            <artifactId>gt-main</artifactId>
-            <version>${geotools.version}</version>
+            <groupId>org.datasyslab</groupId>
+            <artifactId>geotools-wrapper</artifactId>
+            <version>geotools-${geotools.version}</version>
             <scope>${geotools.scope}</scope>
             <exclusions>
                 <exclusion>
                     <groupId>org.locationtech.jts</groupId>
                     <artifactId>jts-core</artifactId>
                 </exclusion>
-                <exclusion>
-                    <groupId>com.fasterxml.jackson.core</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <!--for CRS transformation-->
-        <dependency>
-            <groupId>org.geotools</groupId>
-            <artifactId>gt-referencing</artifactId>
-            <version>${geotools.version}</version>
-            <scope>${geotools.scope}</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.fasterxml.jackson.core</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <!--for CRS transformation-->
-        <dependency>
-            <groupId>org.geotools</groupId>
-            <artifactId>gt-epsg-hsql</artifactId>
-            <version>${geotools.version}</version>
-            <scope>${geotools.scope}</scope>
-            <exclusions>
                 <exclusion>
                     <groupId>com.fasterxml.jackson.core</groupId>
                     <artifactId>*</artifactId>

--- a/sql/src/test/scala/org/apache/sedona/sql/adapterTestScala.scala
+++ b/sql/src/test/scala/org/apache/sedona/sql/adapterTestScala.scala
@@ -28,9 +28,8 @@ import org.apache.sedona.sql.utils.Adapter
 import org.apache.spark.sql.sedona_sql.UDT.GeometryUDT
 import org.apache.spark.storage.StorageLevel
 import org.scalatest.GivenWhenThen
-import org.scalatest.matchers.should.Matchers
 
-class adapterTestScala extends TestBaseScala with Matchers with GivenWhenThen{
+class adapterTestScala extends TestBaseScala with GivenWhenThen{
 
   describe("Sedona-SQL Scala Adapter Test") {
 

--- a/viz/src/test/scala/org/apache/sedona/viz/sql/TestBaseScala.scala
+++ b/viz/src/test/scala/org/apache/sedona/viz/sql/TestBaseScala.scala
@@ -42,7 +42,6 @@ trait TestBaseScala extends FunSpec with BeforeAndAfterAll{
   override def beforeAll(): Unit = {
     spark = SparkSession.builder().config("spark.serializer", classOf[KryoSerializer].getName).
       config("spark.kryo.registrator", classOf[SedonaVizKryoRegistrator].getName).
-      config("spark.sql.view.maxNestedViewDepth", "300").
       master("local[*]").appName("SedonaVizSQL").getOrCreate()
     SedonaSQLRegistrator.registerAll(spark)
     SedonaVizRegistrator.registerAll(spark)

--- a/viz/src/test/scala/org/apache/sedona/viz/sql/TestBaseScala.scala
+++ b/viz/src/test/scala/org/apache/sedona/viz/sql/TestBaseScala.scala
@@ -23,7 +23,7 @@ import org.apache.sedona.sql.utils.SedonaSQLRegistrator
 import org.apache.sedona.viz.core.Serde.SedonaVizKryoRegistrator
 import org.apache.sedona.viz.sql.utils.SedonaVizRegistrator
 import org.apache.spark.serializer.KryoSerializer
-import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.{DataFrame, SparkSession}
 import org.scalatest.{BeforeAndAfterAll, FunSpec}
 
 trait TestBaseScala extends FunSpec with BeforeAndAfterAll{
@@ -42,9 +42,24 @@ trait TestBaseScala extends FunSpec with BeforeAndAfterAll{
   override def beforeAll(): Unit = {
     spark = SparkSession.builder().config("spark.serializer", classOf[KryoSerializer].getName).
       config("spark.kryo.registrator", classOf[SedonaVizKryoRegistrator].getName).
+      config("spark.sql.view.maxNestedViewDepth", "300").
       master("local[*]").appName("SedonaVizSQL").getOrCreate()
     SedonaSQLRegistrator.registerAll(spark)
     SedonaVizRegistrator.registerAll(spark)
+    getPoint().createOrReplaceTempView("pointtable")
+    getPolygon().createOrReplaceTempView("usdata")
+  }
+
+  def getPoint(): DataFrame = {
+    val pointDf = spark.read.format("csv").option("delimiter", ",").option("header", "false").load(csvPointInputLocation).sample(false, 1)
+    pointDf.selectExpr("ST_Point(cast(_c0 as Decimal(24,20)),cast(_c1 as Decimal(24,20))) as shape")
+      .filter("ST_Contains(ST_PolygonFromEnvelope(-126.790180,24.863836,-64.630926,50.000),shape)")
+  }
+
+  def getPolygon():DataFrame = {
+    val polygonDf = spark.read.format("csv").option("delimiter", "\t").option("header", "false").load(polygonInputLocationWkt)
+    polygonDf.selectExpr("ST_GeomFromWKT(_c0) as shape", "_c1 as rate", "_c2", "_c3")
+      .filter("ST_Contains(ST_PolygonFromEnvelope(-126.790180,24.863836,-64.630926,50.000),shape)")
   }
 
   override def afterAll(): Unit = {

--- a/viz/src/test/scala/org/apache/sedona/viz/sql/optVizOperatorTest.scala
+++ b/viz/src/test/scala/org/apache/sedona/viz/sql/optVizOperatorTest.scala
@@ -33,7 +33,7 @@ class optVizOperatorTest extends TestBaseScala {
         """
           |CREATE OR REPLACE TEMP VIEW pixels AS
           |SELECT pixel, shape FROM pointtable
-          |LATERAL VIEW ST_Pixelize(shape, 1000, 1000, ST_PolygonFromEnvelope(-126.790180,24.863836,-64.630926,50.000)) AS pixel
+          |LATERAL VIEW EXPLODE(ST_Pixelize(shape, 1000, 1000, ST_PolygonFromEnvelope(-126.790180,24.863836,-64.630926,50.000))) AS pixel
         """.stripMargin)
 
       // Test visualization partitioner
@@ -64,7 +64,7 @@ class optVizOperatorTest extends TestBaseScala {
         """
           |CREATE OR REPLACE TEMP VIEW pixels AS
           |SELECT pixel, shape FROM pointtable
-          |LATERAL VIEW ST_Pixelize(shape, 1000, 1000, ST_PolygonFromEnvelope(-126.790180,24.863836,-64.630926,50.000)) AS pixel
+          |LATERAL VIEW EXPLODE(ST_Pixelize(shape, 1000, 1000, ST_PolygonFromEnvelope(-126.790180,24.863836,-64.630926,50.000))) AS pixel
         """.stripMargin)
 
       // Test visualization partitioner

--- a/viz/src/test/scala/org/apache/sedona/viz/sql/optVizOperatorTest.scala
+++ b/viz/src/test/scala/org/apache/sedona/viz/sql/optVizOperatorTest.scala
@@ -29,21 +29,6 @@ class optVizOperatorTest extends TestBaseScala {
   describe("SedonaViz SQL function Test") {
 
     it("Passed full pipeline using optimized operator") {
-      var pointDf = spark.read.format("csv").option("delimiter", ",").option("header", "false").load(csvPointInputLocation) //.createOrReplaceTempView("polygontable")
-      pointDf.createOrReplaceTempView("pointtable")
-      spark.sql(
-        """
-          |CREATE OR REPLACE TEMP VIEW pointtable AS
-          |SELECT ST_Point(cast(pointtable._c0 as Decimal(24,20)),cast(pointtable._c1 as Decimal(24,20))) as shape
-          |FROM pointtable
-        """.stripMargin)
-      spark.sql(
-        """
-          |CREATE OR REPLACE TEMP VIEW pointtable AS
-          |SELECT *
-          |FROM pointtable
-          |WHERE ST_Contains(ST_PolygonFromEnvelope(-126.790180,24.863836,-64.630926,50.000),shape)
-        """.stripMargin)
       spark.sql(
         """
           |CREATE OR REPLACE TEMP VIEW pixels AS
@@ -75,21 +60,6 @@ class optVizOperatorTest extends TestBaseScala {
     }
 
     it("Passed full pipeline - aggregate:avg - color:uniform") {
-      var pointDf = spark.read.format("csv").option("delimiter", ",").option("header", "false").load(csvPointInputLocation) //.createOrReplaceTempView("polygontable")
-      pointDf.createOrReplaceTempView("pointtable")
-      spark.sql(
-        """
-          |CREATE OR REPLACE TEMP VIEW pointtable AS
-          |SELECT ST_Point(cast(pointtable._c0 as Decimal(24,20)),cast(pointtable._c1 as Decimal(24,20))) as shape
-          |FROM pointtable
-        """.stripMargin)
-      spark.sql(
-        """
-          |CREATE OR REPLACE TEMP VIEW pointtable AS
-          |SELECT *
-          |FROM pointtable
-          |WHERE ST_Contains(ST_PolygonFromEnvelope(-126.790180,24.863836,-64.630926,50.000),shape)
-        """.stripMargin)
       spark.sql(
         """
           |CREATE OR REPLACE TEMP VIEW pixels AS

--- a/viz/src/test/scala/org/apache/sedona/viz/sql/standardVizOperatorTest.scala
+++ b/viz/src/test/scala/org/apache/sedona/viz/sql/standardVizOperatorTest.scala
@@ -27,21 +27,6 @@ class standardVizOperatorTest extends TestBaseScala {
   describe("SedonaViz SQL function Test") {
 
     it("Generate a single image") {
-      var pointDf = spark.read.format("csv").option("delimiter", ",").option("header", "false").load(csvPointInputLocation) //.createOrReplaceTempView("polygontable")
-      pointDf.sample(false, 1).createOrReplaceTempView("pointtable")
-      spark.sql(
-        """
-          |CREATE OR REPLACE TEMP VIEW pointtable AS
-          |SELECT ST_Point(cast(pointtable._c0 as Decimal(24,20)),cast(pointtable._c1 as Decimal(24,20))) as shape
-          |FROM pointtable
-        """.stripMargin)
-      spark.sql(
-        """
-          |CREATE OR REPLACE TEMP VIEW pointtable AS
-          |SELECT *
-          |FROM pointtable
-          |WHERE ST_Contains(ST_PolygonFromEnvelope(-126.790180,24.863836,-64.630926,50.000),shape)
-        """.stripMargin)
       spark.sql(
         """
           |CREATE OR REPLACE TEMP VIEW pixels AS
@@ -74,21 +59,6 @@ class standardVizOperatorTest extends TestBaseScala {
     }
 
     it("Generate a single image using a fat query") {
-      var pointDf = spark.read.format("csv").option("delimiter", ",").option("header", "false").load(csvPointInputLocation) //.createOrReplaceTempView("polygontable")
-      pointDf.sample(false, 1).createOrReplaceTempView("pointtable")
-      spark.sql(
-        """
-          |CREATE OR REPLACE TEMP VIEW pointtable AS
-          |SELECT ST_Point(cast(pointtable._c0 as Decimal(24,20)),cast(pointtable._c1 as Decimal(24,20))) as shape
-          |FROM pointtable
-        """.stripMargin)
-      spark.sql(
-        """
-          |CREATE OR REPLACE TEMP VIEW pointtable AS
-          |SELECT *
-          |FROM pointtable
-          |WHERE ST_Contains(ST_PolygonFromEnvelope(-126.790180,24.863836,-64.630926,50.000),shape)
-        """.stripMargin)
       spark.sql(
         """
           |CREATE OR REPLACE TEMP VIEW boundtable AS
@@ -117,21 +87,6 @@ class standardVizOperatorTest extends TestBaseScala {
     }
 
     it("Passed the pipeline on points") {
-      var pointDf = spark.read.format("csv").option("delimiter", ",").option("header", "false").load(csvPointInputLocation) //.createOrReplaceTempView("polygontable")
-      pointDf.createOrReplaceTempView("pointtable")
-      spark.sql(
-        """
-          |CREATE OR REPLACE TEMP VIEW pointtable AS
-          |SELECT ST_Point(cast(pointtable._c0 as Decimal(24,20)),cast(pointtable._c1 as Decimal(24,20))) as shape
-          |FROM pointtable
-        """.stripMargin)
-      spark.sql(
-        """
-          |CREATE OR REPLACE TEMP VIEW pointtable AS
-          |SELECT *
-          |FROM pointtable
-          |WHERE ST_Contains(ST_PolygonFromEnvelope(-126.790180,24.863836,-64.630926,50.000),shape)
-        """.stripMargin)
       spark.sql(
         """
           |CREATE OR REPLACE TEMP VIEW pixels AS
@@ -150,21 +105,6 @@ class standardVizOperatorTest extends TestBaseScala {
     }
 
     it("Passed the pipeline on polygons") {
-      var polygonDf = spark.read.format("csv").option("delimiter", "\t").option("header", "false").load(polygonInputLocationWkt)
-      polygonDf.createOrReplaceTempView("polygontable")
-      spark.sql(
-        """
-          |CREATE OR REPLACE TEMP VIEW polygontable AS
-          |SELECT ST_GeomFromWKT(polygontable._c0) as shape, _c1 as rate, _c2, _c3
-          |FROM polygontable
-        """.stripMargin)
-      spark.sql(
-        """
-          |CREATE OR REPLACE TEMP VIEW usdata AS
-          |SELECT *
-          |FROM polygontable
-          |WHERE ST_Contains(ST_PolygonFromEnvelope(-126.790180,24.863836,-64.630926,50.000),shape)
-        """.stripMargin)
       spark.sql(
         """
           |CREATE OR REPLACE TEMP VIEW pixels AS
@@ -195,22 +135,7 @@ class standardVizOperatorTest extends TestBaseScala {
     }
 
     it("Passed ST_TileName") {
-      var pointDf = spark.read.format("csv").option("delimiter", ",").option("header", "false").load(csvPointInputLocation)
       var zoomLevel = 2
-      pointDf.sample(false, 0.01).createOrReplaceTempView("pointtable")
-      spark.sql(
-        """
-          |CREATE OR REPLACE TEMP VIEW pointtable AS
-          |SELECT ST_Point(cast(pointtable._c0 as Decimal(24,20)),cast(pointtable._c1 as Decimal(24,20))) as shape
-          |FROM pointtable
-        """.stripMargin)
-      spark.sql(
-        """
-          |CREATE OR REPLACE TEMP VIEW pointtable AS
-          |SELECT *
-          |FROM pointtable
-          |WHERE ST_Contains(ST_PolygonFromEnvelope(-126.790180,24.863836,-64.630926,50.000),shape)
-        """.stripMargin)
       spark.sql(
         """
           |CREATE OR REPLACE TEMP VIEW pixels AS

--- a/viz/src/test/scala/org/apache/sedona/viz/sql/standardVizOperatorTest.scala
+++ b/viz/src/test/scala/org/apache/sedona/viz/sql/standardVizOperatorTest.scala
@@ -31,7 +31,7 @@ class standardVizOperatorTest extends TestBaseScala {
         """
           |CREATE OR REPLACE TEMP VIEW pixels AS
           |SELECT pixel, shape FROM pointtable
-          |LATERAL VIEW ST_Pixelize(shape, 256, 256, ST_PolygonFromEnvelope(-126.790180,24.863836,-64.630926,50.000)) AS pixel
+          |LATERAL VIEW EXPLODE(ST_Pixelize(shape, 256, 256, ST_PolygonFromEnvelope(-126.790180,24.863836,-64.630926,50.000)) ) AS pixel
         """.stripMargin)
       spark.sql(
         """
@@ -68,7 +68,7 @@ class standardVizOperatorTest extends TestBaseScala {
         """
           |CREATE OR REPLACE TEMP VIEW pixels AS
           |SELECT pixel, shape FROM pointtable
-          |LATERAL VIEW ST_Pixelize(ST_Transform(ST_FlipCoordinates(shape), 'epsg:4326','epsg:3857'), 256, 256, (SELECT ST_Transform(ST_FlipCoordinates(bound), 'epsg:4326','epsg:3857') FROM boundtable)) AS pixel
+          |LATERAL VIEW EXPLODE(ST_Pixelize(ST_Transform(ST_FlipCoordinates(shape), 'epsg:4326','epsg:3857'), 256, 256, (SELECT ST_Transform(ST_FlipCoordinates(bound), 'epsg:4326','epsg:3857') FROM boundtable))) AS pixel
         """.stripMargin)
       spark.sql(
         """
@@ -91,7 +91,7 @@ class standardVizOperatorTest extends TestBaseScala {
         """
           |CREATE OR REPLACE TEMP VIEW pixels AS
           |SELECT pixel, shape FROM pointtable
-          |LATERAL VIEW ST_Pixelize(shape, 1000, 800, ST_PolygonFromEnvelope(-126.790180,24.863836,-64.630926,50.000)) AS pixel
+          |LATERAL VIEW EXPLODE(ST_Pixelize(shape, 1000, 800, ST_PolygonFromEnvelope(-126.790180,24.863836,-64.630926,50.000))) AS pixel
         """.stripMargin)
       spark.sql(
         """
@@ -109,7 +109,7 @@ class standardVizOperatorTest extends TestBaseScala {
         """
           |CREATE OR REPLACE TEMP VIEW pixels AS
           |SELECT pixel, rate, shape FROM usdata
-          |LATERAL VIEW ST_Pixelize(shape, 1000, 1000, ST_PolygonFromEnvelope(-126.790180,24.863836,-64.630926,50.000)) AS pixel
+          |LATERAL VIEW EXPLODE(ST_Pixelize(shape, 1000, 1000, ST_PolygonFromEnvelope(-126.790180,24.863836,-64.630926,50.000))) AS pixel
         """.stripMargin)
       spark.sql(
         """
@@ -140,7 +140,7 @@ class standardVizOperatorTest extends TestBaseScala {
         """
           |CREATE OR REPLACE TEMP VIEW pixels AS
           |SELECT pixel, shape FROM pointtable
-          |LATERAL VIEW ST_Pixelize(shape, 1000, 1000, ST_PolygonFromEnvelope(-126.790180,24.863836,-64.630926,50.000)) AS pixel
+          |LATERAL VIEW EXPLODE(ST_Pixelize(shape, 1000, 1000, ST_PolygonFromEnvelope(-126.790180,24.863836,-64.630926,50.000))) AS pixel
         """.stripMargin)
       spark.sql(
         """
@@ -151,7 +151,7 @@ class standardVizOperatorTest extends TestBaseScala {
         """.stripMargin)
       spark.sql(
         s"""
-          |CREATE OR REPLACE TEMP VIEW pixelaggregates AS
+          |CREATE OR REPLACE TEMP VIEW pixel_weights AS
           |SELECT pixel, weight, ST_TileName(pixel, $zoomLevel) AS pid
           |FROM pixelaggregates
         """.stripMargin)
@@ -159,7 +159,7 @@ class standardVizOperatorTest extends TestBaseScala {
         """
           |CREATE OR REPLACE TEMP VIEW images AS
           |SELECT ST_Render(pixel, ST_Colorize(weight, (SELECT max(weight) FROM pixelaggregates))) AS image
-          |FROM pixelaggregates
+          |FROM pixel_weights
           |GROUP BY pid
         """.stripMargin).explain()
       spark.table("images").show(1)


### PR DESCRIPTION
## Is this PR related to a proposed Issue?

https://issues.apache.org/jira/browse/SEDONA-29

## What changes were proposed in this PR?

1. Tweak all workflows to support Spark 2.4, 3.0, 3.1 CI
2. Rewrite ST_Pixelize using Expression instead of Generator to make Lateral View recognize this function

## How was this patch tested?

Passed the unit tests

## Did this PR include necessary documentation updates?
Yes