### PR TITLE
[SEDONA-35] address user-data mutability issue with `Adapter.toDF()`

### DIFF
--- a/sql/src/main/scala/org/apache/sedona/sql/utils/Adapter.scala
+++ b/sql/src/main/scala/org/apache/sedona/sql/utils/Adapter.scala
@@ -113,11 +113,14 @@ object Adapter {
   }
 
   def toDf[T <: Geometry](spatialRDD: SpatialRDD[T], fieldNames: Seq[String], sparkSession: SparkSession): DataFrame = {
-    val rowRdd = spatialRDD.rawSpatialRDD.rdd.map[Row](f => {
-      var userData = f.getUserData
-      f.setUserData(null)
-      if (userData != null) Row.fromSeq(f +: userData.asInstanceOf[String].split("\t", -1))
-      else Row.fromSeq(Seq(f))
+    val rowRdd = spatialRDD.rawSpatialRDD.rdd.map[Row](geom => {
+      val userData = geom.getUserData
+      val geomWithoutUserData = geom.copy
+      geomWithoutUserData.setUserData(null)
+      if (userData != null)
+        Row.fromSeq(geomWithoutUserData +: userData.asInstanceOf[String].split("\t", -1))
+      else
+        Row.fromSeq(Seq(geom))
     })
     var cols:Seq[StructField] = Seq(StructField("geometry", GeometryUDT))
     if (fieldNames != null && fieldNames.nonEmpty) {

--- a/sql/src/main/scala/org/apache/sedona/sql/utils/Adapter.scala
+++ b/sql/src/main/scala/org/apache/sedona/sql/utils/Adapter.scala
@@ -169,8 +169,9 @@ object Adapter {
     if (fieldNames != null && fieldNames.nonEmpty) {
       val userData = "" + geom.getUserData.asInstanceOf[String]
       val fields = userData.split("\t")
-//      geom.setUserData(null) // Set to null will lead to the null pointer exception of the previous line. Not sure why.
-      (Seq(geom), fields)
+      val geomWithoutUserData = geom.copy
+      geomWithoutUserData.setUserData(null)
+      (Seq(geomWithoutUserData), fields)
     }
     else (Seq(geom), Seq())
   }


### PR DESCRIPTION
Signed-off-by: Yitao Li <yitao@rstudio.com>

## Is this PR related to a proposed Issue?

https://issues.apache.org/jira/browse/SEDONA-35

I think we should create an issue for it.

The problem is currently if `Adapter.toDf()` is called with a `SpatialRDD` carrying non-spatial attributes (a.k.a "user data") in addition to spatial attributes, then the Spark dataframe returned from `toDf()` can only be evaluated successfully once. If it was  evaluated more than once, then a null pointer exception occurrs. If a Spark dataframe is not cached, then the underlying RDD could be evaluated more than once in many scenarios, so, the NPE problem could break quite a few use cases.

## What changes were proposed in this PR?

Essentially, the changes in this PR ensures `toDf()` respects the immutability of `RDD`s in Spark. The abovementioned NPE issue happens because the `Geometry` objects stored in the input `RDD` have their `userData` set to `null` within a `RDD.map` transformation, and this causes unexpected `null` values (at least when Spark is running in "local" mode) when this transformation is evaluated the second time.

So, the short-term fix (as shown in this PR) is to operate on a copy of the `Geometry` object, rather than modifying the `Geometry` object that is already stored in the `RDD`.

Long-term fix: I think it would be a better practice to work with `RDD[ImmutableGeometry]`s where `ImmutableGeometry` is a sub-class of `Geometry` that does not permit modifications of its existing data fields, but permits copying its underling data to a mutable `Geometry` object. I'm unsure whether there may be noticeable perf impact with this type of change though and I hope to get a second opinion on this. But this feels like, in principle, the correct thing to do, because `RDD`s are by design supposed to be immutable in Spark, and correctness issue arises if the immutability contract is not followed.

## How was this patch tested?

Unit test (in progress)

## Did this PR include necessary documentation updates?

Not applicable -- there is no change to documentation