### PR TITLE
[SEDONA-41]fix RangeFilter when the leftCoveredByRight parameter is f…

### DIFF
--- a/core/src/main/java/org/apache/sedona/core/rangeJudgement/RangeFilter.java
+++ b/core/src/main/java/org/apache/sedona/core/rangeJudgement/RangeFilter.java
@@ -44,7 +44,7 @@ public class RangeFilter<U extends Geometry, T extends Geometry>
             return match(geometry, queryGeometry);
         }
         else {
-            return match(queryGeometry, queryGeometry);
+            return match(queryGeometry, geometry);
         }
     }
 }

--- a/core/src/test/java/org/apache/sedona/core/rangeJudgement/RangeFilterTest.java
+++ b/core/src/test/java/org/apache/sedona/core/rangeJudgement/RangeFilterTest.java
@@ -1,0 +1,161 @@
+package org.apache.sedona.core.rangeJudgement;
+
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.Envelope;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.Polygon;
+import org.apache.log4j.Level;
+import org.apache.log4j.Logger;
+import org.apache.sedona.core.enums.FileDataSplitter;
+import org.apache.sedona.core.enums.IndexType;
+import org.apache.sedona.core.spatialOperator.RectangleRangeTest;
+import org.apache.sedona.core.spatialRDD.RectangleRDD;
+import org.apache.spark.SparkConf;
+import org.apache.spark.api.java.JavaSparkContext;
+import org.apache.spark.storage.StorageLevel;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+
+import static org.junit.Assert.assertEquals;
+
+// TODO: Auto-generated Javadoc
+
+/**
+ * The Class RangeFilterTest.
+ */
+public class RangeFilterTest {
+
+    /**
+     * The sc.
+     */
+    public static JavaSparkContext sc;
+
+    /**
+     * The prop.
+     */
+    static Properties prop;
+
+    /**
+     * The input.
+     */
+    static InputStream input;
+
+    /**
+     * The Input location.
+     */
+    static String InputLocation;
+
+    /**
+     * The offset.
+     */
+    static Integer offset;
+
+    /**
+     * The splitter.
+     */
+    static FileDataSplitter splitter;
+
+    /**
+     * The index type.
+     */
+    static IndexType indexType;
+
+    /**
+     * The num partitions.
+     */
+    static Integer numPartitions;
+
+    /**
+     * The query envelope.
+     */
+    static Envelope queryEnvelope;
+
+    /**
+     * The loop times.
+     */
+    static int loopTimes;
+
+    /**
+     * Once executed before all.
+     */
+    @BeforeClass
+    public static void onceExecutedBeforeAll() {
+        SparkConf conf = new SparkConf().setAppName("RangeFilter").setMaster("local[2]");
+        sc = new JavaSparkContext(conf);
+        Logger.getLogger("org").setLevel(Level.WARN);
+        Logger.getLogger("akka").setLevel(Level.WARN);
+        prop = new Properties();
+        input = RectangleRangeTest.class.getClassLoader().getResourceAsStream("rectangle.test.properties");
+
+        //Hard code to a file in resource folder. But you can replace it later in the try-catch field in your hdfs system.
+        InputLocation = "file://" + RectangleRangeTest.class.getClassLoader().getResource("zcta510-small.csv").getPath();
+
+        offset = 0;
+        splitter = null;
+        indexType = null;
+        numPartitions = 0;
+
+        try {
+            // load a properties file
+            prop.load(input);
+            // There is a field in the property file, you can edit your own file location there.
+            // InputLocation = prop.getProperty("inputLocation");
+            InputLocation = "file://" + RectangleRangeTest.class.getClassLoader().getResource(prop.getProperty("inputLocation")).getPath();
+            offset = Integer.parseInt(prop.getProperty("offset"));
+            splitter = FileDataSplitter.getFileDataSplitter(prop.getProperty("splitter"));
+            indexType = IndexType.getIndexType(prop.getProperty("indexType"));
+            numPartitions = Integer.parseInt(prop.getProperty("numPartitions"));
+            queryEnvelope = new Envelope(-90.08663, -90.057982, 29.919004, 29.95859);
+            loopTimes = 5;
+        } catch (IOException ex) {
+            ex.printStackTrace();
+        } finally {
+            if (input != null) {
+                try {
+                    input.close();
+                } catch (IOException e) {
+                    e.printStackTrace();
+                }
+            }
+        }
+    }
+
+    /**
+     * Tear down.
+     */
+    @AfterClass
+    public static void TearDown() {
+        sc.stop();
+    }
+
+
+    /**
+     * Test spatial range query not using index and leftCoveredByRight is false.
+     *
+     * @throws Exception the exception
+     */
+    @Test
+    public void testSpatialRangeQueryLeftCoveredByRightFalse()
+            throws Exception {
+        RectangleRDD spatialRDD = new RectangleRDD(sc, InputLocation, offset, splitter, true, StorageLevel.MEMORY_ONLY());
+        Coordinate[] coordinates = new Coordinate[5];
+        coordinates[0] = new Coordinate(queryEnvelope.getMinX(), queryEnvelope.getMinY());
+        coordinates[1] = new Coordinate(queryEnvelope.getMinX(), queryEnvelope.getMaxY());
+        coordinates[2] = new Coordinate(queryEnvelope.getMaxX(), queryEnvelope.getMaxY());
+        coordinates[3] = new Coordinate(queryEnvelope.getMaxX(), queryEnvelope.getMinY());
+        coordinates[4] = coordinates[0];
+        GeometryFactory geometryFactory = new GeometryFactory();
+        Polygon queryGeometry = geometryFactory.createPolygon(coordinates);
+        spatialRDD.buildIndex(IndexType.RTREE, false);
+        long useIndexResultSize = spatialRDD.indexedRawRDD.mapPartitions(new RangeFilterUsingIndex(queryGeometry, false, false)).count();
+        for (int i = 0; i < loopTimes; i++) {
+            long notUseIndexResultSize = spatialRDD.getRawSpatialRDD().filter(new RangeFilter(queryGeometry, false, false)).count();
+            assertEquals(useIndexResultSize, notUseIndexResultSize);
+        }
+    }
+}


### PR DESCRIPTION
## Is this PR related to a proposed Issue?

https://issues.apache.org/jira/browse/SEDONA-41

## What changes were proposed in this PR?
RangeFilter When the leftCoveredByRight parameter is fase, the second parameter of the match() method is called and modified to geometry
## How was this patch tested?
the example for test code
`
SpatialRDD pointRDD = new PointRDD(sc, "arealm-small.csv", 0, FileDataSplitter.CSV,true);
Coordinate[] coordinates = new Coordinate[5];
coordinates[0] = new Coordinate(-90.01, 30.01);
coordinates[1] = new Coordinate(-90.01, 40.01);
coordinates[2] = new Coordinate(-80.01, 40.01);
coordinates[3] = new Coordinate(-80.01, 30.01);
coordinates[4] = coordinates[0];
GeometryFactory geometryFactory = new GeometryFactory();
Polygon queryGeometry = geometryFactory.createPolygon(coordinates);
JavaRDD<Geometry> rdd = RangeQuery.SpatialRangeQuery(queryGeometry, spatialRDD, false, false);
`
## Did this PR include necessary documentation updates?
this PR Fix RangeFilter when the leftCoveredByRight parameter is fase, the wrong match result is returned due to parameter passing errors