### PR TITLE
[SEDONA-50] Removing logging configuration as it causes errors on databricks.

### DIFF
--- a/python/sedona/core/jvm/config.py
+++ b/python/sedona/core/jvm/config.py
@@ -15,17 +15,13 @@
 #  specific language governing permissions and limitations
 #  under the License.
 
+import logging
 import os
 from re import findall
 from typing import Optional
-import logging
 
 from pyspark.sql import SparkSession
-
 from sedona.utils.decorators import classproperty
-
-FORMAT = '%(asctime) %(message)s'
-logging.basicConfig(format=FORMAT)
 
 
 def is_greater_or_equal_version(version_a: str, version_b: str) -> bool:
@@ -49,8 +45,10 @@ def since(version: str):
         def applier(*args, **kwargs):
             sedona_version = SedonaMeta.version
             if not is_greater_or_equal_version(sedona_version, version):
-                logging.warning(f"This function is not available for {sedona_version}, "
-                                f"please use version higher than {version}")
+                logging.warning(
+                    f"This function is not available for {sedona_version}, "
+                    f"please use version higher than {version}"
+                )
                 raise AttributeError(f"Not available before {version} sedona version")
             result = function(*args, **kwargs)
             return result
@@ -77,7 +75,6 @@ def depreciated(version: str, substitute: str):
 
 
 class SparkJars:
-
     @staticmethod
     def get_used_jars():
         spark = SparkSession._instantiatedSession
@@ -90,11 +87,17 @@ class SparkJars:
         try:
             used_jar_files = java_spark_conf.get("spark.jars")
         except Exception as e:
-            logging.warning(f"Failed to get the value of spark.jars from SparkConf: {e}")
+            logging.warning(
+                f"Failed to get the value of spark.jars from SparkConf: {e}"
+            )
         finally:
             if not used_jar_files:
-                logging.info("Trying to get filenames from the $SPARK_HOME/jars directory")
-                used_jar_files = ",".join(os.listdir(os.path.join(os.environ["SPARK_HOME"], "jars")))
+                logging.info(
+                    "Trying to get filenames from the $SPARK_HOME/jars directory"
+                )
+                used_jar_files = ",".join(
+                    os.listdir(os.path.join(os.environ["SPARK_HOME"], "jars"))
+                )
         return used_jar_files
 
     @property
@@ -105,11 +108,13 @@ class SparkJars:
 
 
 class SedonaMeta:
-
     @classmethod
     def get_version(cls, spark_jars: str) -> Optional[str]:
         # Find Spark version, Scala version and Sedona version.
-        versions = findall(r"sedona-python-adapter-([^,\n]+)_([^,\n]+)-([^,\n]+)-incubating", spark_jars)
+        versions = findall(
+            r"sedona-python-adapter-([^,\n]+)_([^,\n]+)-([^,\n]+)-incubating",
+            spark_jars,
+        )
         try:
             sedona_version = versions[0][2]
         except IndexError:


### PR DESCRIPTION
## Is this PR related to a proposed Issue?

https://issues.apache.org/jira/browse/SEDONA-50

## What changes were proposed in this PR?
Importing this file causes logging issues within databricks.

![image](https://user-images.githubusercontent.com/6853645/121194091-68fdf980-c83c-11eb-9cac-b8696b81a6cf.png)

Full error:
```
--- Logging error ---
Traceback (most recent call last):
  File "/usr/lib/python3.7/logging/__init__.py", line 1025, in emit
    msg = self.format(record)
  File "/usr/lib/python3.7/logging/__init__.py", line 869, in format
    return fmt.format(record)
  File "/usr/lib/python3.7/logging/__init__.py", line 611, in format
    s = self.formatMessage(record)
  File "/usr/lib/python3.7/logging/__init__.py", line 580, in formatMessage
    return self._style.format(record)
  File "/usr/lib/python3.7/logging/__init__.py", line 422, in format
    return self._fmt % record.__dict__
ValueError: unsupported format character '%' (0x25) at index 11
Call stack:
  File "/local_disk0/tmp/1623158547967-0/PythonShell.py", line 30, in <module>
    launch_process()
  File "/local_disk0/tmp/1623158547967-0/PythonShellImpl.py", line 1907, in launch_process
    shell.executor.run()
  File "/local_disk0/tmp/1623158547967-0/PythonShellImpl.py", line 285, in run
    self.shell.shell.run_cell(command_id, cmd, store_history=True)
  File "/local_disk0/tmp/1623158547967-0/PythonShellImpl.py", line 1233, in run_cell
    super(IPythonShell, self).run_cell(raw_cell, store_history, silent, shell_futures)
  File "/databricks/python/lib/python3.7/site-packages/IPython/core/interactiveshell.py", line 2858, in run_cell
    raw_cell, store_history, silent, shell_futures)
  File "/databricks/python/lib/python3.7/site-packages/IPython/core/interactiveshell.py", line 2886, in _run_cell
    return runner(coro)
  File "/databricks/python/lib/python3.7/site-packages/IPython/core/async_helpers.py", line 68, in _pseudo_sync_runner
    coro.send(None)
  File "/databricks/python/lib/python3.7/site-packages/IPython/core/interactiveshell.py", line 3063, in run_cell_async
    interactivity=interactivity, compiler=compiler, result=result)
  File "/databricks/python/lib/python3.7/site-packages/IPython/core/interactiveshell.py", line 3254, in run_ast_nodes
    if (await self.run_code(code, result,  async_=asy)):
  File "/databricks/python/lib/python3.7/site-packages/IPython/core/interactiveshell.py", line 3331, in run_code
    exec(code_obj, self.user_global_ns, self.user_ns)
  File "<command-3221151447083464>", line 3, in <module>
    logging.warning("Test2")
Message: 'Test2'
Arguments: ()
```

## How was this patch tested?
I manually removed this line and the logging will work again.  It is unclear why the library is doing this.
