### PR TITLE
[SEDONA-56] Fix broadcast join with AQE enabled

### DIFF
--- a/sql/src/main/scala/org/apache/spark/sql/sedona_sql/strategy/join/SpatialIndexExec.scala
+++ b/sql/src/main/scala/org/apache/spark/sql/sedona_sql/strategy/join/SpatialIndexExec.scala
@@ -26,8 +26,7 @@ import org.apache.spark.internal.Logging
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{Attribute, BindReferences, Expression, UnsafeRow}
-import org.apache.spark.sql.execution.SparkPlan
-import org.apache.spark.sql.execution.exchange.Exchange
+import org.apache.spark.sql.execution.{SparkPlan, UnaryExecNode}
 
 
 
@@ -35,7 +34,7 @@ case class SpatialIndexExec(child: SparkPlan,
                             shape: Expression,
                             indexType: IndexType,
                             radius: Option[Expression] = None)
-  extends Exchange
+  extends UnaryExecNode
     with TraitJoinQueryBase
     with Logging {
 


### PR DESCRIPTION
## Is this PR related to a proposed Issue?
https://issues.apache.org/jira/browse/SEDONA-56

## What changes were proposed in this PR?
Small fix for SpatialIndexExec to just extend UnaryExecNode instead of Exchange to make it run with AQE enabled.

## How was this patch tested?
New unit test.

## Did this PR include necessary documentation updates?
None needed, bug fix.
