### PR TITLE
use GITHUB_TOKEN to authenticate `remotes::install_github()` web requests

### DIFF
--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -40,6 +40,10 @@ jobs:
     env:
       SPARK_VERSION: ${{ matrix.spark }}
       SCALA_VERSION: ${{ matrix.scala }}
+      # Ensure the temporary auth token for this workflow, instead of the
+      # bundled GitHub PAT from the `remotes` package is used for
+      # `remotes::install_github()`
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Delete existing R binaries
         run: |


### PR DESCRIPTION
Signed-off-by: Yitao Li <yitao@rstudio.com>

## Is this PR related to a proposed Issue?

No.

## What changes were proposed in this PR?

This is a trivial change to fix the GitHub rate-limiting problem encountered in https://github.com/apache/incubator-sedona/pull/534

## How was this patch tested?

via GitHub Actions workflows for R builds

## Did this PR include necessary documentation updates?

No.
