### PR TITLE
Make pyspark dependency of sedona python optional

### DIFF
--- a/docs/download/overview.md
+++ b/docs/download/overview.md
@@ -56,6 +56,11 @@ You need to install necessary packages if your system does not have them install
 ```bash
 pip install apache-sedona
 ```
+* Since version 1.1.0 pyspark is an optional dependency since spark comes pre-installed on many spark platforms.
+  To install pyspark along with Sedona Python in one go, use the `spark` extra:
+```bash
+pip install apache-sedona[spark]
+```
 
 * Installing from Sedona Python source
 

--- a/python/setup.py
+++ b/python/setup.py
@@ -36,7 +36,8 @@ setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     python_requires='>=3.6',
-    install_requires=['pyspark>=2.3.0', 'attrs', "shapely"],
+    install_requires=['attrs', "shapely"],
+    extras_require={"spark": ['pyspark>=2.4.0']},
     project_urls={
         'Documentation': 'https://sedona.apache.org',
         'Source code': 'https://github.com/apache/incubator-sedona',


### PR DESCRIPTION
## Is this PR related to a proposed Issue?

Yes - this implements https://issues.apache.org/jira/browse/SEDONA-59

## What changes were proposed in this PR?

This PR moves the `pyspark` dependency to a extra dependency called spark. Allowing to

- Get apache-sedona and the pyspark pip package in one go:
```bash
pip install apache-sedona[spark]
```
- Or get only apache sedona its dependencies except for pyspark:
```bash
pip install apache-sedona
```

## How was this patch tested?

Built python wheel locally and tested that the two `pip install` commands above work as expected.

## Did this PR include necessary documentation updates?

Added a note in the install docs.



<sub>Sebastian Eckweiler (sebastian.eckweiler@daimler.com), Mercedes-Benz AG on behalf of MBition GmbH ([Imprint](https://github.com/Daimler/daimler-foss/blob/master/LEGAL_IMPRINT.md))</sub>