### PR TITLE
[SEDONA-63] Skip empty partitions in NestedLoopJudgement

### DIFF
--- a/core/src/main/java/org/apache/sedona/core/joinJudgement/NestedLoopJudgement.java
+++ b/core/src/main/java/org/apache/sedona/core/joinJudgement/NestedLoopJudgement.java
@@ -29,6 +29,7 @@ import javax.annotation.Nullable;
 
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 
@@ -50,6 +51,10 @@ public class NestedLoopJudgement<T extends Geometry, U extends Geometry>
     public Iterator<Pair<U, T>> call(Iterator<T> iteratorObject, Iterator<U> iteratorWindow)
             throws Exception
     {
+        if (!iteratorObject.hasNext() || !iteratorWindow.hasNext()) {
+            return Collections.emptyIterator();
+        }
+
         initPartition();
 
         List<Pair<U, T>> result = new ArrayList<>();


### PR DESCRIPTION
## Is this PR related to a proposed Issue?

https://issues.apache.org/jira/browse/SEDONA-63

## What changes were proposed in this PR?

Return immediately if one of the sides is empty in NestedLoopJudgement as already implemented in indexed join judgements.

## How was this patch tested?

Current set of test in Sedona should cover this change. 

Small performance improvement (~10%) observed with some of our Sedona jobs.

## Did this PR include necessary documentation updates?

No documentation changes needed.
