### PR TITLE
[SEDONA-22] [SEDONA-60] Fix join in Spark SQL when one side has no rows or only one row

### DIFF
--- a/core/src/main/java/org/apache/sedona/core/spatialRDD/SpatialRDD.java
+++ b/core/src/main/java/org/apache/sedona/core/spatialRDD/SpatialRDD.java
@@ -220,7 +220,7 @@ public class SpatialRDD<T extends Geometry>
             throw new Exception("[AbstractSpatialRDD][spatialPartitioning] SpatialRDD boundary is null. Please call analyze() first.");
         }
         if (this.approximateTotalCount == -1) {
-            throw new Exception("[AbstractSpatialRDD][spatialPartitioning] SpatialRDD total count is unkown. Please call analyze() first.");
+            throw new Exception("[AbstractSpatialRDD][spatialPartitioning] SpatialRDD total count is unknown. Please call analyze() first.");
         }
 
         //Calculate the number of samples we need to take.
@@ -259,7 +259,8 @@ public class SpatialRDD<T extends Geometry>
                 break;
             }
             case KDBTREE: {
-                final KDBTree tree = new KDBTree(samples.size() / numPartitions, numPartitions, paddedBoundary);
+                int maxItemsPerNode = Math.max(samples.size() / numPartitions, 1);
+                final KDBTree tree = new KDBTree(maxItemsPerNode, numPartitions, paddedBoundary);
                 for (final Envelope sample : samples) {
                     tree.insert(sample);
                 }

--- a/core/src/main/java/org/apache/sedona/core/utils/RDDSampleUtils.java
+++ b/core/src/main/java/org/apache/sedona/core/utils/RDDSampleUtils.java
@@ -56,7 +56,7 @@ public class RDDSampleUtils
         }
 
         // Make sure that number of records >= 2 * number of partitions
-        if (totalNumberOfRecords < 2 * numPartitions) {
+        if (numPartitions > (totalNumberOfRecords + 1) / 2) {
             throw new IllegalArgumentException("[Sedona] Number of partitions " + numPartitions + " cannot be larger than half of total records num " + totalNumberOfRecords);
         }
 
@@ -64,7 +64,7 @@ public class RDDSampleUtils
             return (int) totalNumberOfRecords;
         }
 
-        final int minSampleCnt = numPartitions * 2;
+        final long minSampleCnt = Math.min(numPartitions * 2L, totalNumberOfRecords);
         return (int) Math.max(minSampleCnt, Math.min(totalNumberOfRecords / 100, Integer.MAX_VALUE));
     }
 }

--- a/core/src/test/java/org/apache/sedona/core/utils/RDDSampleUtilsTest.java
+++ b/core/src/test/java/org/apache/sedona/core/utils/RDDSampleUtilsTest.java
@@ -41,6 +41,7 @@ public class RDDSampleUtilsTest
         assertEquals(99, RDDSampleUtils.getSampleNumbers(6, 100011, 99));
         assertEquals(999, RDDSampleUtils.getSampleNumbers(20, 999, -1));
         assertEquals(40, RDDSampleUtils.getSampleNumbers(20, 1000, -1));
+        assertEquals(1, RDDSampleUtils.getSampleNumbers(1, 1, -1));
     }
 
     /**
@@ -52,6 +53,7 @@ public class RDDSampleUtilsTest
         assertFailure(505, 999);
         assertFailure(505, 1000);
         assertFailure(10, 1000, 2100);
+        assertFailure(2, 1, -1);
     }
 
     private void assertFailure(int numPartitions, long totalNumberOfRecords)

--- a/sql/src/main/scala/org/apache/spark/sql/sedona_sql/strategy/join/TraitJoinQueryBase.scala
+++ b/sql/src/main/scala/org/apache/spark/sql/sedona_sql/strategy/join/TraitJoinQueryBase.scala
@@ -69,7 +69,9 @@ trait TraitJoinQueryBase {
 
   def doSpatialPartitioning(dominantShapes: SpatialRDD[Geometry], followerShapes: SpatialRDD[Geometry],
                             numPartitions: Integer, sedonaConf: SedonaConf): Unit = {
-    dominantShapes.spatialPartitioning(sedonaConf.getJoinGridType, numPartitions)
-    followerShapes.spatialPartitioning(dominantShapes.getPartitioner)
+    if (dominantShapes.approximateTotalCount > 0) {
+      dominantShapes.spatialPartitioning(sedonaConf.getJoinGridType, numPartitions)
+      followerShapes.spatialPartitioning(dominantShapes.getPartitioner)
+    }
   }
 }


### PR DESCRIPTION
## Is this PR related to a proposed Issue?

Yes, [SEDONA-60](https://issues.apache.org/jira/browse/SEDONA-60) and [SEDONA-22](https://issues.apache.org/jira/browse/SEDONA-22).

## What changes were proposed in this PR?

This patch fixes spatial joins performed in Spark SQL: when the dominant side contains only one row or no rows, we'd like to perform the join as usual instead of raising exceptions.

## How was this patch tested?

We've added new unit tests to cover these 2 cases.

## Did this PR include necessary documentation updates?

No.