### PR TITLE
[SEDONA-67] Support Spark 3.2

### DIFF
--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        spark: [2.4.7, 3.0.3, 3.1.2, 3.2.0]
+        spark: [2.4.8, 3.0.3, 3.1.2, 3.2.0]
         scala: [2.11.8, 2.12.15]
         exclude:
           - spark: 3.2.0

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -14,12 +14,14 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        spark: [2.4.7, 3.0.2, 3.1.1]
-        scala: [2.11.8, 2.12.8]
+        spark: [2.4.7, 3.0.3, 3.1.2, 3.2.0]
+        scala: [2.11.8, 2.12.15]
         exclude:
-          - spark: 3.1.1
+          - spark: 3.2.0
             scala: 2.11.8
-          - spark: 3.0.2
+          - spark: 3.1.2
+            scala: 2.11.8
+          - spark: 3.0.3
             scala: 2.11.8
 
     steps:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -15,19 +15,22 @@ jobs:
     strategy:
       matrix:
         include:
-          - spark: 3.1.1
-            scala: 2.12.8
-            python: 3.7
-          - spark: 3.1.1
-            scala: 2.12.8
-            python: 3.8
-          - spark: 3.1.1
+          - spark: 3.2.0
             scala: 2.12.8
             python: 3.9
-          - spark: 3.0.2
+          - spark: 3.2.0
+            scala: 2.12.8
+            python: 3.8
+          - spark: 3.2.0
             scala: 2.12.8
             python: 3.7
-          - spark: 2.4.7
+          - spark: 3.1.2
+            scala: 2.12.8
+            python: 3.7
+          - spark: 3.0.3
+            scala: 2.12.8
+            python: 3.7
+          - spark: 2.4.8
             scala: 2.11.8
             python: 3.7
 

--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -37,10 +37,10 @@ jobs:
           - spark: 3.0.3
             scala: 2.11.8
             r: release
-          - spark: 2.4.7
+          - spark: 2.4.8
             scala: 2.12.8
             r: oldrel
-          - spark: 2.4.7
+          - spark: 2.4.8
             scala: 2.12.8
             r: release
     env:

--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -15,20 +15,26 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        spark: [2.4.7, 3.0.2, 3.1.1]
+        spark: [2.4.8, 3.0.3, 3.1.2, 3.2.0]
         scala: [2.11.8, 2.12.8]
         r: [oldrel, release]
         exclude:
-          - spark: 3.1.1
+          - spark: 3.2.0
             scala: 2.11.8
             r: oldrel
-          - spark: 3.1.1
+          - spark: 3.2.0
+            scala: 2.11.8
+            r: release          
+          - spark: 3.1.2
+            scala: 2.11.8
+            r: oldrel
+          - spark: 3.1.2
             scala: 2.11.8
             r: release
-          - spark: 3.0.2
+          - spark: 3.0.3
             scala: 2.11.8
             r: oldrel
-          - spark: 3.0.2
+          - spark: 3.0.3
             scala: 2.11.8
             r: release
           - spark: 2.4.7

--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        spark: [2.4.8, 3.0.3, 3.1.2, 3.2.0]
+        spark: [2.4.8, 3.0.3, 3.1.2]
         scala: [2.11.8, 2.12.8]
         r: [oldrel, release]
         exclude:

--- a/pom.xml
+++ b/pom.xml
@@ -513,7 +513,7 @@
             </repositories>
         </profile>
         <profile>
-            <id>spark3.0</id>
+            <id>spark3.2</id>
             <activation>
                 <property>
                     <name>spark</name>
@@ -522,7 +522,24 @@
                 <activeByDefault>true</activeByDefault>
             </activation>
             <properties>
-                <spark.version>3.1.1</spark.version>
+                <spark.version>3.2.0</spark.version>
+                <spark.compat.version>3.0</spark.compat.version>
+                <spark.converter.version>spark3</spark.converter.version>
+                <jackson.version>2.12.5</jackson.version>
+                <maven.deploy.skip>true</maven.deploy.skip>
+            </properties>
+        </profile>
+        <profile>
+            <id>spark3.0</id>
+            <activation>
+                <property>
+                    <name>spark</name>
+                    <value>3.0</value>
+                </property>
+                <activeByDefault>false</activeByDefault>
+            </activation>
+            <properties>
+                <spark.version>3.1.2</spark.version>
                 <spark.compat.version>3.0</spark.compat.version>
                 <spark.converter.version>spark3</spark.converter.version>
                 <jackson.version>2.10.0</jackson.version>
@@ -556,7 +573,7 @@
                 <activeByDefault>true</activeByDefault>
             </activation>
             <properties>
-                <scala.version>2.12.8</scala.version>
+                <scala.version>2.12.15</scala.version>
                 <scala.compat.version>2.12</scala.compat.version>
                 <scaladoc.arg>-no-java-comments</scaladoc.arg>
             </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -356,6 +356,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
                 <executions>
                     <execution>
                         <phase>compile</phase>
@@ -513,7 +514,7 @@
             </repositories>
         </profile>
         <profile>
-            <id>spark3.2</id>
+            <id>spark3.0</id>
             <activation>
                 <property>
                     <name>spark</name>
@@ -527,23 +528,6 @@
                 <spark.converter.version>spark3</spark.converter.version>
                 <jackson.version>2.12.5</jackson.version>
                 <maven.deploy.skip>true</maven.deploy.skip>
-            </properties>
-        </profile>
-        <profile>
-            <id>spark3.0</id>
-            <activation>
-                <property>
-                    <name>spark</name>
-                    <value>3.0</value>
-                </property>
-                <activeByDefault>false</activeByDefault>
-            </activation>
-            <properties>
-                <spark.version>3.1.2</spark.version>
-                <spark.compat.version>3.0</spark.compat.version>
-                <spark.converter.version>spark3</spark.converter.version>
-                <jackson.version>2.10.0</jackson.version>
-                <maven.deploy.skip>false</maven.deploy.skip>
             </properties>
         </profile>
         <profile>

--- a/pom.xml
+++ b/pom.xml
@@ -527,7 +527,7 @@
                 <spark.compat.version>3.0</spark.compat.version>
                 <spark.converter.version>spark3</spark.converter.version>
                 <jackson.version>2.12.5</jackson.version>
-                <maven.deploy.skip>true</maven.deploy.skip>
+                <maven.deploy.skip>false</maven.deploy.skip>
             </properties>
         </profile>
         <profile>

--- a/python/tests/serialization/test_deserializers.py
+++ b/python/tests/serialization/test_deserializers.py
@@ -65,11 +65,6 @@ class TestGeometryConvert(TestBase):
 
         assert geom.area == 712.5
 
-    def test_multipolygon_deserialization(self):
-        geom = self.spark.sql(
-            """select st_geomFromWKT()"""
-        )
-
     def test_point_deserialization(self):
         geom = self.spark.sql("""SELECT st_geomfromtext('POINT(-6.0 52.0)') as geom""").collect()[0][0]
         assert geom.wkt == Point(-6.0, 52.0).wkt

--- a/sql/src/main/scala/org/apache/spark/sql/sedona_sql/execution/SedonaSparkPlan.scala
+++ b/sql/src/main/scala/org/apache/spark/sql/sedona_sql/execution/SedonaSparkPlan.scala
@@ -1,0 +1,30 @@
+package org.apache.spark.sql.sedona_sql.execution
+
+import org.apache.spark.sql.execution.SparkPlan
+
+trait SedonaUnaryExecNode extends SparkPlan {
+  def child: SparkPlan
+
+  override final def children: Seq[SparkPlan] = child :: Nil
+
+  final def withNewChildrenInternal(newChildren: IndexedSeq[SparkPlan]): SparkPlan = {
+    assert(newChildren.size == 1, "Incorrect number of children")
+    withNewChildInternal(newChildren.head)
+  }
+
+  protected def withNewChildInternal(newChild: SparkPlan): SparkPlan
+}
+
+trait SedonaBinaryExecNode extends SparkPlan {
+  def left: SparkPlan
+  def right: SparkPlan
+
+  override final def children: Seq[SparkPlan] = Seq(left, right)
+
+  final def withNewChildrenInternal(newChildren: IndexedSeq[SparkPlan]): SparkPlan = {
+    assert(newChildren.size == 2, "Incorrect number of children")
+    withNewChildrenInternal(newChildren(0), newChildren(1))
+  }
+
+  protected def withNewChildrenInternal(newLeft: SparkPlan, newRight: SparkPlan): SparkPlan
+}

--- a/sql/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/Constructors.scala
+++ b/sql/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/Constructors.scala
@@ -40,22 +40,27 @@ import org.locationtech.jts.geom.{Coordinate, GeometryFactory}
   */
 case class ST_PointFromText(inputExpressions: Seq[Expression])
   extends Expression with CodegenFallback with UserDataGeneratator {
+  // This is an expression which takes two input expressions.
+  assert(inputExpressions.length == 2)
+
   override def nullable: Boolean = false
 
   override def eval(inputRow: InternalRow): Any = {
-    // This is an expression which takes two input expressions.
-    assert(inputExpressions.length == 2)
     val geomString = inputExpressions(0).eval(inputRow).asInstanceOf[UTF8String].toString
     val geomFormat = inputExpressions(1).eval(inputRow).asInstanceOf[UTF8String].toString
     var fileDataSplitter = FileDataSplitter.getFileDataSplitter(geomFormat)
     var formatMapper = new FormatMapper(fileDataSplitter, false, GeometryType.POINT)
     var geometry = formatMapper.readGeometry(geomString)
-    return new GenericArrayData(GeometrySerializer.serialize(geometry))
+    new GenericArrayData(GeometrySerializer.serialize(geometry))
   }
 
   override def dataType: DataType = GeometryUDT
 
   override def children: Seq[Expression] = inputExpressions
+
+  protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
+    copy(inputExpressions = newChildren)
+  }
 }
 
 /**
@@ -65,23 +70,28 @@ case class ST_PointFromText(inputExpressions: Seq[Expression])
   */
 case class ST_PolygonFromText(inputExpressions: Seq[Expression])
   extends Expression with CodegenFallback with UserDataGeneratator {
+  // This is an expression which takes two input expressions.
+  assert(inputExpressions.length == 2)
+
   override def nullable: Boolean = false
 
   override def eval(inputRow: InternalRow): Any = {
-    // This is an expression which takes two input expressions.
-    assert(inputExpressions.length == 2)
     val geomString = inputExpressions(0).eval(inputRow).asInstanceOf[UTF8String].toString
     val geomFormat = inputExpressions(1).eval(inputRow).asInstanceOf[UTF8String].toString
 
     var fileDataSplitter = FileDataSplitter.getFileDataSplitter(geomFormat)
     var formatMapper = new FormatMapper(fileDataSplitter, false, GeometryType.POLYGON)
     var geometry = formatMapper.readGeometry(geomString)
-    return new GenericArrayData(GeometrySerializer.serialize(geometry))
+    new GenericArrayData(GeometrySerializer.serialize(geometry))
   }
 
   override def dataType: DataType = GeometryUDT
 
   override def children: Seq[Expression] = inputExpressions
+
+  protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
+    copy(inputExpressions = newChildren)
+  }
 }
 
 /**
@@ -91,12 +101,12 @@ case class ST_PolygonFromText(inputExpressions: Seq[Expression])
   */
 case class ST_LineStringFromText(inputExpressions: Seq[Expression])
   extends Expression with CodegenFallback with UserDataGeneratator {
+  // This is an expression which takes two input expressions.
+  assert(inputExpressions.length == 2)
+
   override def nullable: Boolean = false
 
   override def eval(inputRow: InternalRow): Any = {
-    // This is an expression which takes two input expressions.
-    assert(inputExpressions.length == 2)
-
     val geomString = inputExpressions(0).eval(inputRow).asInstanceOf[UTF8String].toString
     val geomFormat = inputExpressions(1).eval(inputRow).asInstanceOf[UTF8String].toString
 
@@ -104,12 +114,16 @@ case class ST_LineStringFromText(inputExpressions: Seq[Expression])
     var formatMapper = new FormatMapper(fileDataSplitter, false, GeometryType.LINESTRING)
     var geometry = formatMapper.readGeometry(geomString)
 
-    return new GenericArrayData(GeometrySerializer.serialize(geometry))
+    new GenericArrayData(GeometrySerializer.serialize(geometry))
   }
 
   override def dataType: DataType = GeometryUDT
 
   override def children: Seq[Expression] = inputExpressions
+
+  protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
+    copy(inputExpressions = newChildren)
+  }
 }
 
 
@@ -120,21 +134,26 @@ case class ST_LineStringFromText(inputExpressions: Seq[Expression])
   */
 case class ST_GeomFromWKT(inputExpressions: Seq[Expression])
   extends Expression with CodegenFallback with UserDataGeneratator {
+  // This is an expression which takes one input expressions
+  assert(inputExpressions.length == 1)
+
   override def nullable: Boolean = false
 
   override def eval(inputRow: InternalRow): Any = {
-    // This is an expression which takes one input expressions
-    assert(inputExpressions.length == 1)
     val geomString = inputExpressions(0).eval(inputRow).asInstanceOf[UTF8String].toString
     var fileDataSplitter = FileDataSplitter.WKT
     var formatMapper = new FormatMapper(fileDataSplitter, false)
     var geometry = formatMapper.readGeometry(geomString)
-    return new GenericArrayData(GeometrySerializer.serialize(geometry))
+    new GenericArrayData(GeometrySerializer.serialize(geometry))
   }
 
   override def dataType: DataType = GeometryUDT
 
   override def children: Seq[Expression] = inputExpressions
+
+  protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
+    copy(inputExpressions = newChildren)
+  }
 }
 
 
@@ -145,21 +164,26 @@ case class ST_GeomFromWKT(inputExpressions: Seq[Expression])
   */
 case class ST_GeomFromText(inputExpressions: Seq[Expression])
   extends Expression with CodegenFallback with UserDataGeneratator {
+  // This is an expression which takes one input expressions
+  assert(inputExpressions.length == 1)
+
   override def nullable: Boolean = false
 
   override def eval(inputRow: InternalRow): Any = {
-    // This is an expression which takes one input expressions
-    assert(inputExpressions.length == 1)
     val geomString = inputExpressions(0).eval(inputRow).asInstanceOf[UTF8String].toString
     var fileDataSplitter = FileDataSplitter.WKT
     var formatMapper = new FormatMapper(fileDataSplitter, false)
     var geometry = formatMapper.readGeometry(geomString)
-    return new GenericArrayData(GeometrySerializer.serialize(geometry))
+    new GenericArrayData(GeometrySerializer.serialize(geometry))
   }
 
   override def dataType: DataType = GeometryUDT
 
   override def children: Seq[Expression] = inputExpressions
+
+  protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
+    copy(inputExpressions = newChildren)
+  }
 }
 
 
@@ -170,21 +194,26 @@ case class ST_GeomFromText(inputExpressions: Seq[Expression])
   */
 case class ST_GeomFromWKB(inputExpressions: Seq[Expression])
   extends Expression with CodegenFallback with UserDataGeneratator {
+  // This is an expression which takes one input expressions
+  assert(inputExpressions.length == 1)
+
   override def nullable: Boolean = false
 
   override def eval(inputRow: InternalRow): Any = {
-    // This is an expression which takes one input expressions
-    assert(inputExpressions.length == 1)
-    val geomString = inputExpressions(0).eval(inputRow).asInstanceOf[UTF8String].toString
+    val geomString = inputExpressions.head.eval(inputRow).asInstanceOf[UTF8String].toString
     var fileDataSplitter = FileDataSplitter.WKB
     var formatMapper = new FormatMapper(fileDataSplitter, false)
     var geometry = formatMapper.readGeometry(geomString)
-    return new GenericArrayData(GeometrySerializer.serialize(geometry))
+    new GenericArrayData(GeometrySerializer.serialize(geometry))
   }
 
   override def dataType: DataType = GeometryUDT
 
   override def children: Seq[Expression] = inputExpressions
+
+  protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
+    copy(inputExpressions = newChildren)
+  }
 }
 
 /**
@@ -194,14 +223,14 @@ case class ST_GeomFromWKB(inputExpressions: Seq[Expression])
   */
 case class ST_GeomFromGeoJSON(inputExpressions: Seq[Expression])
   extends Expression with CodegenFallback with UserDataGeneratator {
+  // This is an expression which takes one input expressions
+  val minInputLength = 1
+  assert(inputExpressions.length >= minInputLength)
+
   override def nullable: Boolean = false
 
   override def eval(inputRow: InternalRow): Any = {
-    // This is an expression which takes one input expressions
-    val minInputLength = 1
-    assert(inputExpressions.length >= minInputLength)
-
-    val geomString = inputExpressions(0).eval(inputRow).asInstanceOf[UTF8String].toString
+    val geomString = inputExpressions.head.eval(inputRow).asInstanceOf[UTF8String].toString
 
     var fileDataSplitter = FileDataSplitter.GEOJSON
     var formatMapper = new FormatMapper(fileDataSplitter, false)
@@ -210,12 +239,16 @@ case class ST_GeomFromGeoJSON(inputExpressions: Seq[Expression])
     if (inputExpressions.length > 1) {
       geometry.setUserData(generateUserData(minInputLength, inputExpressions, inputRow))
     }
-    return new GenericArrayData(GeometrySerializer.serialize(geometry))
+    new GenericArrayData(GeometrySerializer.serialize(geometry))
   }
 
   override def dataType: DataType = GeometryUDT
 
   override def children: Seq[Expression] = inputExpressions
+
+  protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
+    copy(inputExpressions = newChildren)
+  }
 }
 
 /**
@@ -225,10 +258,11 @@ case class ST_GeomFromGeoJSON(inputExpressions: Seq[Expression])
   */
 case class ST_Point(inputExpressions: Seq[Expression])
   extends Expression with CodegenFallback with UserDataGeneratator {
+  assert(inputExpressions.length == 2)
+
   override def nullable: Boolean = false
 
   override def eval(inputRow: InternalRow): Any = {
-    assert(inputExpressions.length == 2)
     val x = inputExpressions(0).eval(inputRow) match {
       case a: Double => a
       case b: Decimal => b.toDouble
@@ -240,12 +274,16 @@ case class ST_Point(inputExpressions: Seq[Expression])
 
     var geometryFactory = new GeometryFactory()
     var geometry = geometryFactory.createPoint(new Coordinate(x, y))
-    return new GenericArrayData(GeometrySerializer.serialize(geometry))
+    new GenericArrayData(GeometrySerializer.serialize(geometry))
   }
 
   override def dataType: DataType = GeometryUDT
 
   override def children: Seq[Expression] = inputExpressions
+
+  protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
+    copy(inputExpressions = newChildren)
+  }
 }
 
 
@@ -254,12 +292,13 @@ case class ST_Point(inputExpressions: Seq[Expression])
   *
   * @param inputExpressions
   */
-case class ST_PolygonFromEnvelope(inputExpressions: Seq[Expression]) extends Expression with CodegenFallback with UserDataGeneratator {
+case class ST_PolygonFromEnvelope(inputExpressions: Seq[Expression])
+  extends Expression with CodegenFallback with UserDataGeneratator {
+  assert(inputExpressions.length == 4)
+
   override def nullable: Boolean = false
 
   override def eval(input: InternalRow): Any = {
-    assert(inputExpressions.length == 4)
-
     val minX = inputExpressions(0).eval(input) match {
       case a: Double => a
       case b: Decimal => b.toDouble
@@ -294,6 +333,10 @@ case class ST_PolygonFromEnvelope(inputExpressions: Seq[Expression]) extends Exp
   override def dataType: DataType = GeometryUDT
 
   override def children: Seq[Expression] = inputExpressions
+
+  protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
+    copy(inputExpressions = newChildren)
+  }
 }
 
 trait UserDataGeneratator {
@@ -308,16 +351,17 @@ trait UserDataGeneratator {
 }
 
 
-case class ST_GeomFromGeoHash(inputExpressions: Seq[Expression]) extends Expression with CodegenFallback{
+case class ST_GeomFromGeoHash(inputExpressions: Seq[Expression])
+  extends Expression with CodegenFallback {
+  assert(inputExpressions.length >= 1 && inputExpressions.length <= 2)
   override def nullable: Boolean = true
 
   override def eval(input: InternalRow): Any = {
-
     val geoHash = Option(inputExpressions.head.eval(input))
       .map(_.asInstanceOf[UTF8String].toString)
     val precision = inputExpressions.tail.headOption.map(_.toInt(input))
 
-    try{
+    try {
       geoHash match {
         case Some(value) => GeoHashDecoder.decode(value, precision).toGenericArrayData
         case None => null
@@ -332,4 +376,8 @@ case class ST_GeomFromGeoHash(inputExpressions: Seq[Expression]) extends Express
   override def dataType: DataType = GeometryUDT
 
   override def children: Seq[Expression] = inputExpressions
+
+  protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
+    copy(inputExpressions = newChildren)
+  }
 }

--- a/sql/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/Functions.scala
+++ b/sql/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/Functions.scala
@@ -1402,7 +1402,8 @@ case class ST_SubDivide(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_SubDivideExplode(children: Seq[Expression]) extends Generator {
+case class ST_SubDivideExplode(children: Seq[Expression])
+  extends Generator with CodegenFallback {
   children.validateLength(2)
 
   override def eval(input: InternalRow): TraversableOnce[InternalRow] = {
@@ -1420,8 +1421,6 @@ case class ST_SubDivideExplode(children: Seq[Expression]) extends Generator {
     new StructType()
       .add("geom", GeometryUDT, true)
   }
-
-  override protected def doGenCode(ctx: CodegenContext, ev: ExprCode): ExprCode = ev
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(children = newChildren)

--- a/sql/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/Functions.scala
+++ b/sql/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/Functions.scala
@@ -59,19 +59,13 @@ import scala.util.{Failure, Success, Try}
   */
 case class ST_Distance(inputExpressions: Seq[Expression])
   extends Expression with CodegenFallback {
-
-  // This is a binary expression
   assert(inputExpressions.length == 2)
 
   override def nullable: Boolean = false
 
   override def toString: String = s" **${ST_Distance.getClass.getName}**  "
 
-  override def children: Seq[Expression] = inputExpressions
-
   override def eval(inputRow: InternalRow): Any = {
-    assert(inputExpressions.length == 2)
-
     val leftArray = inputExpressions(0).eval(inputRow).asInstanceOf[ArrayData]
     val rightArray = inputExpressions(1).eval(inputRow).asInstanceOf[ArrayData]
 
@@ -79,10 +73,16 @@ case class ST_Distance(inputExpressions: Seq[Expression])
 
     val rightGeometry = GeometrySerializer.deserialize(rightArray)
 
-    return leftGeometry.distance(rightGeometry)
+    leftGeometry.distance(rightGeometry)
   }
 
   override def dataType = DoubleType
+
+  override def children: Seq[Expression] = inputExpressions
+
+  protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
+    copy(inputExpressions = newChildren)
+  }
 }
 
 /**
@@ -92,17 +92,22 @@ case class ST_Distance(inputExpressions: Seq[Expression])
   */
 case class ST_ConvexHull(inputExpressions: Seq[Expression])
   extends Expression with CodegenFallback {
+  assert(inputExpressions.length == 1)
+
   override def nullable: Boolean = false
 
   override def eval(input: InternalRow): Any = {
-    assert(inputExpressions.length == 1)
-    val geometry = GeometrySerializer.deserialize(inputExpressions(0).eval(input).asInstanceOf[ArrayData])
+    val geometry = GeometrySerializer.deserialize(inputExpressions.head.eval(input).asInstanceOf[ArrayData])
     new GenericArrayData(GeometrySerializer.serialize(geometry.convexHull()))
   }
 
   override def dataType: DataType = GeometryUDT
 
   override def children: Seq[Expression] = inputExpressions
+
+  protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
+    copy(inputExpressions = newChildren)
+  }
 }
 
 /**
@@ -117,7 +122,7 @@ case class ST_NPoints(inputExpressions: Seq[Expression])
   override def eval(input: InternalRow): Any = {
     inputExpressions.length match {
       case 1 =>
-        val geometry = GeometrySerializer.deserialize(inputExpressions(0).eval(input).asInstanceOf[ArrayData])
+        val geometry = GeometrySerializer.deserialize(inputExpressions.head.eval(input).asInstanceOf[ArrayData])
         geometry.getCoordinates.length
       case _ => None
     }
@@ -127,6 +132,9 @@ case class ST_NPoints(inputExpressions: Seq[Expression])
 
   override def children: Seq[Expression] = inputExpressions
 
+  protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
+    copy(inputExpressions = newChildren)
+  }
 }
 
 /**
@@ -136,10 +144,11 @@ case class ST_NPoints(inputExpressions: Seq[Expression])
   */
 case class ST_Buffer(inputExpressions: Seq[Expression])
   extends Expression with CodegenFallback {
+  assert(inputExpressions.length == 2)
+
   override def nullable: Boolean = false
 
   override def eval(input: InternalRow): Any = {
-    assert(inputExpressions.length == 2)
     val geometry = GeometrySerializer.deserialize(inputExpressions(0).eval(input).asInstanceOf[ArrayData])
     val buffer: Double = inputExpressions(1).eval(input) match {
       case a: Decimal => a.toDouble
@@ -152,6 +161,10 @@ case class ST_Buffer(inputExpressions: Seq[Expression])
   override def dataType: DataType = GeometryUDT
 
   override def children: Seq[Expression] = inputExpressions
+
+  protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
+    copy(inputExpressions = newChildren)
+  }
 }
 
 
@@ -162,17 +175,22 @@ case class ST_Buffer(inputExpressions: Seq[Expression])
   */
 case class ST_Envelope(inputExpressions: Seq[Expression])
   extends Expression with CodegenFallback {
+  assert(inputExpressions.length == 1)
+
   override def nullable: Boolean = false
 
   override def eval(input: InternalRow): Any = {
-    assert(inputExpressions.length == 1)
-    val geometry = GeometrySerializer.deserialize(inputExpressions(0).eval(input).asInstanceOf[ArrayData])
+    val geometry = GeometrySerializer.deserialize(inputExpressions.head.eval(input).asInstanceOf[ArrayData])
     new GenericArrayData(GeometrySerializer.serialize(geometry.getEnvelope()))
   }
 
   override def dataType: DataType = GeometryUDT
 
   override def children: Seq[Expression] = inputExpressions
+
+  protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
+    copy(inputExpressions = newChildren)
+  }
 }
 
 /**
@@ -182,17 +200,22 @@ case class ST_Envelope(inputExpressions: Seq[Expression])
   */
 case class ST_Length(inputExpressions: Seq[Expression])
   extends Expression with CodegenFallback {
+  assert(inputExpressions.length == 1)
+
   override def nullable: Boolean = false
 
   override def eval(input: InternalRow): Any = {
-    assert(inputExpressions.length == 1)
-    val geometry = GeometrySerializer.deserialize(inputExpressions(0).eval(input).asInstanceOf[ArrayData])
-    return geometry.getLength
+    val geometry = GeometrySerializer.deserialize(inputExpressions.head.eval(input).asInstanceOf[ArrayData])
+    geometry.getLength
   }
 
   override def dataType: DataType = DoubleType
 
   override def children: Seq[Expression] = inputExpressions
+
+  protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
+    copy(inputExpressions = newChildren)
+  }
 }
 
 /**
@@ -202,17 +225,22 @@ case class ST_Length(inputExpressions: Seq[Expression])
   */
 case class ST_Area(inputExpressions: Seq[Expression])
   extends Expression with CodegenFallback {
+  assert(inputExpressions.length == 1)
+
   override def nullable: Boolean = false
 
   override def eval(input: InternalRow): Any = {
-    assert(inputExpressions.length == 1)
-    val geometry = GeometrySerializer.deserialize(inputExpressions(0).eval(input).asInstanceOf[ArrayData])
-    return geometry.getArea
+    val geometry = GeometrySerializer.deserialize(inputExpressions.head.eval(input).asInstanceOf[ArrayData])
+    geometry.getArea
   }
 
   override def dataType: DataType = DoubleType
 
   override def children: Seq[Expression] = inputExpressions
+
+  protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
+    copy(inputExpressions = newChildren)
+  }
 }
 
 /**
@@ -222,10 +250,11 @@ case class ST_Area(inputExpressions: Seq[Expression])
   */
 case class ST_Centroid(inputExpressions: Seq[Expression])
   extends Expression with CodegenFallback {
+  assert(inputExpressions.length == 1)
+
   override def nullable: Boolean = false
 
   override def eval(input: InternalRow): Any = {
-    assert(inputExpressions.length == 1)
     val geometry = GeometrySerializer.deserialize(inputExpressions(0).eval(input).asInstanceOf[ArrayData])
     new GenericArrayData(GeometrySerializer.serialize(geometry.getCentroid()))
   }
@@ -233,6 +262,10 @@ case class ST_Centroid(inputExpressions: Seq[Expression])
   override def dataType: DataType = GeometryUDT
 
   override def children: Seq[Expression] = inputExpressions
+
+  protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
+    copy(inputExpressions = newChildren)
+  }
 }
 
 /**
@@ -242,11 +275,11 @@ case class ST_Centroid(inputExpressions: Seq[Expression])
   */
 case class ST_Transform(inputExpressions: Seq[Expression])
   extends Expression with CodegenFallback {
+  assert(inputExpressions.length >= 3 && inputExpressions.length <= 4)
+
   override def nullable: Boolean = false
 
   override def eval(input: InternalRow): Any = {
-    assert(inputExpressions.length >= 3 && inputExpressions.length <= 4)
-
     val originalGeometry = GeometrySerializer.deserialize(inputExpressions(0).eval(input).asInstanceOf[ArrayData])
     val sourceCRScode = CRS.decode(inputExpressions(1).eval(input).asInstanceOf[UTF8String].toString)
     val targetCRScode = CRS.decode(inputExpressions(2).eval(input).asInstanceOf[UTF8String].toString)
@@ -265,6 +298,10 @@ case class ST_Transform(inputExpressions: Seq[Expression])
   override def dataType: DataType = GeometryUDT
 
   override def children: Seq[Expression] = inputExpressions
+
+  protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
+    copy(inputExpressions = newChildren)
+  }
 }
 
 
@@ -275,13 +312,14 @@ case class ST_Transform(inputExpressions: Seq[Expression])
   */
 case class ST_Intersection(inputExpressions: Seq[Expression])
   extends Expression with CodegenFallback {
+  assert(inputExpressions.length == 2)
+
   lazy val GeometryFactory = new GeometryFactory()
   lazy val emptyPolygon = GeometryFactory.createPolygon(null, null)
 
   override def nullable: Boolean = false
 
   override def eval(inputRow: InternalRow): Any = {
-    assert(inputExpressions.length == 2)
     val leftgeometry = GeometrySerializer.deserialize(inputExpressions(0).eval(inputRow).asInstanceOf[ArrayData])
     val rightgeometry = GeometrySerializer.deserialize(inputExpressions(1).eval(inputRow).asInstanceOf[ArrayData])
 
@@ -307,6 +345,10 @@ case class ST_Intersection(inputExpressions: Seq[Expression])
   override def dataType: DataType = GeometryUDT
 
   override def children: Seq[Expression] = inputExpressions
+
+  protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
+    copy(inputExpressions = newChildren)
+  }
 }
 
 /**
@@ -316,14 +358,13 @@ case class ST_Intersection(inputExpressions: Seq[Expression])
   */
 case class ST_MakeValid(inputExpressions: Seq[Expression])
   extends Generator with CodegenFallback with UserDataGeneratator {
+  assert(inputExpressions.length == 2)
 
   override def elementSchema: StructType = new StructType().add("Geometry", new GeometryUDT)
 
   override def toString: String = s" **${ST_MakeValid.getClass.getName}** "
 
   override def eval(input: InternalRow): TraversableOnce[InternalRow] = {
-    assert(inputExpressions.length == 2)
-
     val geometry = GeometrySerializer.deserialize(inputExpressions(0).eval(input).asInstanceOf[ArrayData])
     val removeHoles = inputExpressions(1).eval(input).asInstanceOf[Boolean]
 
@@ -356,6 +397,10 @@ case class ST_MakeValid(inputExpressions: Seq[Expression])
   }
 
   override def children: Seq[Expression] = inputExpressions
+
+  protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
+    copy(inputExpressions = newChildren)
+  }
 }
 
 /**
@@ -365,21 +410,27 @@ case class ST_MakeValid(inputExpressions: Seq[Expression])
   */
 case class ST_IsValid(inputExpressions: Seq[Expression])
   extends Expression with CodegenFallback {
+  assert(inputExpressions.length == 1)
+
   override def nullable: Boolean = true
 
   override def eval(input: InternalRow): Any = {
-    assert(inputExpressions.length == 1)
-    if (inputExpressions(0).eval(input).asInstanceOf[ArrayData] == null) {
-      return null
+    val geometry = inputExpressions.head.eval(input).asInstanceOf[ArrayData]
+    if (geometry == null) {
+      null
+    } else {
+      val isvalidop = new IsValidOp(GeometrySerializer.deserialize(geometry))
+      isvalidop.isValid
     }
-    val geometry = GeometrySerializer.deserialize(inputExpressions(0).eval(input).asInstanceOf[ArrayData])
-    val isvalidop = new IsValidOp(geometry)
-    isvalidop.isValid
   }
 
   override def dataType: DataType = BooleanType
 
   override def children: Seq[Expression] = inputExpressions
+
+  protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
+    copy(inputExpressions = newChildren)
+  }
 }
 
 /**
@@ -389,21 +440,23 @@ case class ST_IsValid(inputExpressions: Seq[Expression])
   */
 case class ST_IsSimple(inputExpressions: Seq[Expression])
   extends Expression with CodegenFallback {
+  assert(inputExpressions.length == 1)
+
   override def nullable: Boolean = false
 
   override def eval(input: InternalRow): Any = {
-    assert(inputExpressions.length == 1)
-
-    val geometry = GeometrySerializer.deserialize(inputExpressions(0).eval(input).asInstanceOf[ArrayData])
-
+    val geometry = GeometrySerializer.deserialize(inputExpressions.head.eval(input).asInstanceOf[ArrayData])
     val isSimpleop = new IsSimpleOp(geometry)
-
-    return isSimpleop.isSimple
+    isSimpleop.isSimple
   }
 
   override def dataType: DataType = BooleanType
 
   override def children: Seq[Expression] = inputExpressions
+
+  protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
+    copy(inputExpressions = newChildren)
+  }
 }
 
 /**
@@ -416,11 +469,11 @@ case class ST_IsSimple(inputExpressions: Seq[Expression])
   */
 case class ST_SimplifyPreserveTopology(inputExpressions: Seq[Expression])
   extends Expression with CodegenFallback {
+  assert(inputExpressions.length == 2)
+
   override def nullable: Boolean = false
 
   override def eval(input: InternalRow): Any = {
-    assert(inputExpressions.length == 2)
-
     val geometry = GeometrySerializer.deserialize(inputExpressions(0).eval(input).asInstanceOf[ArrayData])
     val distanceTolerance = inputExpressions(1).eval(input) match {
       case number: Decimal => number.toDouble
@@ -435,6 +488,10 @@ case class ST_SimplifyPreserveTopology(inputExpressions: Seq[Expression])
   override def dataType: DataType = GeometryUDT
 
   override def children: Seq[Expression] = inputExpressions
+
+  protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
+    copy(inputExpressions = newChildren)
+  }
 }
 
 /**
@@ -448,7 +505,6 @@ case class ST_PrecisionReduce(inputExpressions: Seq[Expression])
   override def nullable: Boolean = false
 
   override def eval(input: InternalRow): Any = {
-    assert(inputExpressions.length == 2)
     val geometry = GeometrySerializer.deserialize(inputExpressions(0).eval(input).asInstanceOf[ArrayData])
     val precisionScale = inputExpressions(1).eval(input).asInstanceOf[Int]
     val precisionReduce = new GeometryPrecisionReducer(new PrecisionModel(Math.pow(10, precisionScale)))
@@ -458,21 +514,30 @@ case class ST_PrecisionReduce(inputExpressions: Seq[Expression])
   override def dataType: DataType = GeometryUDT
 
   override def children: Seq[Expression] = inputExpressions
+
+  protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
+    copy(inputExpressions = newChildren)
+  }
 }
 
 case class ST_AsText(inputExpressions: Seq[Expression])
   extends Expression with CodegenFallback {
+  assert(inputExpressions.length == 1)
+
   override def nullable: Boolean = false
 
   override def eval(input: InternalRow): Any = {
-    assert(inputExpressions.length == 1)
-    val geometry = GeometrySerializer.deserialize(inputExpressions(0).eval(input).asInstanceOf[ArrayData])
+    val geometry = GeometrySerializer.deserialize(inputExpressions.head.eval(input).asInstanceOf[ArrayData])
     UTF8String.fromString(geometry.toText)
   }
 
   override def dataType: DataType = StringType
 
   override def children: Seq[Expression] = inputExpressions
+
+  protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
+    copy(inputExpressions = newChildren)
+  }
 }
 
 case class ST_AsGeoJSON(inputExpressions: Seq[Expression])
@@ -480,7 +545,6 @@ case class ST_AsGeoJSON(inputExpressions: Seq[Expression])
   override def nullable: Boolean = false
 
   override def eval(input: InternalRow): Any = {
-    inputExpressions.validateLength(1)
     val geometry = inputExpressions.head.toGeometry(input)
 
     val writer = new GeoJSONWriter()
@@ -490,14 +554,19 @@ case class ST_AsGeoJSON(inputExpressions: Seq[Expression])
   override def dataType: DataType = StringType
 
   override def children: Seq[Expression] = inputExpressions
+
+  protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
+    copy(inputExpressions = newChildren)
+  }
 }
 
 case class ST_AsBinary(inputExpressions: Seq[Expression])
   extends Expression with CodegenFallback {
+  inputExpressions.validateLength(1)
+
   override def nullable: Boolean = false
 
   override def eval(input: InternalRow): Any = {
-    inputExpressions.validateLength(1)
     val geometry = inputExpressions.head.toGeometry(input)
     val dimensions = if (java.lang.Double.isNaN(geometry.getCoordinate.getZ)) 2 else 3
     val endian = if (ByteOrder.nativeOrder() == ByteOrder.BIG_ENDIAN) ByteOrderValues.BIG_ENDIAN else ByteOrderValues.LITTLE_ENDIAN
@@ -508,14 +577,19 @@ case class ST_AsBinary(inputExpressions: Seq[Expression])
   override def dataType: DataType = BinaryType
 
   override def children: Seq[Expression] = inputExpressions
+
+  protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
+    copy(inputExpressions = newChildren)
+  }
 }
 
 case class ST_AsEWKB(inputExpressions: Seq[Expression])
   extends Expression with CodegenFallback {
+  inputExpressions.validateLength(1)
+
   override def nullable: Boolean = false
 
   override def eval(input: InternalRow): Any = {
-    inputExpressions.validateLength(1)
     val geometry = inputExpressions.head.toGeometry(input)
     val dimensions = if (java.lang.Double.isNaN(geometry.getCoordinate.getZ)) 2 else 3
     val endian = if (ByteOrder.nativeOrder() == ByteOrder.BIG_ENDIAN) ByteOrderValues.BIG_ENDIAN else ByteOrderValues.LITTLE_ENDIAN
@@ -526,14 +600,19 @@ case class ST_AsEWKB(inputExpressions: Seq[Expression])
   override def dataType: DataType = BinaryType
 
   override def children: Seq[Expression] = inputExpressions
+
+  protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
+    copy(inputExpressions = newChildren)
+  }
 }
 
 case class ST_SRID(inputExpressions: Seq[Expression])
   extends Expression with CodegenFallback {
+  inputExpressions.validateLength(1)
+
   override def nullable: Boolean = false
 
   override def eval(input: InternalRow): Any = {
-    inputExpressions.validateLength(1)
     val geometry = inputExpressions.head.toGeometry(input)
     geometry.getSRID
   }
@@ -541,14 +620,19 @@ case class ST_SRID(inputExpressions: Seq[Expression])
   override def dataType: DataType = IntegerType
 
   override def children: Seq[Expression] = inputExpressions
+
+  protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
+    copy(inputExpressions = newChildren)
+  }
 }
 
 case class ST_SetSRID(inputExpressions: Seq[Expression])
   extends Expression with CodegenFallback {
+  inputExpressions.validateLength(2)
+
   override def nullable: Boolean = false
 
   override def eval(input: InternalRow): Any = {
-    inputExpressions.validateLength(2)
     val geometry = inputExpressions.head.toGeometry(input)
     val srid = inputExpressions(1).eval(input).asInstanceOf[Integer]
     val factory = new GeometryFactory(geometry.getPrecisionModel, srid, geometry.getFactory.getCoordinateSequenceFactory)
@@ -558,21 +642,30 @@ case class ST_SetSRID(inputExpressions: Seq[Expression])
   override def dataType: DataType = GeometryUDT
 
   override def children: Seq[Expression] = inputExpressions
+
+  protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
+    copy(inputExpressions = newChildren)
+  }
 }
 
 case class ST_GeometryType(inputExpressions: Seq[Expression])
   extends Expression with CodegenFallback {
+  assert(inputExpressions.length == 1)
+
   override def nullable: Boolean = false
 
   override def eval(input: InternalRow): Any = {
-    assert(inputExpressions.length == 1)
-    val geometry = GeometrySerializer.deserialize(inputExpressions(0).eval(input).asInstanceOf[ArrayData])
+    val geometry = GeometrySerializer.deserialize(inputExpressions.head.eval(input).asInstanceOf[ArrayData])
     UTF8String.fromString("ST_" + geometry.getGeometryType)
   }
 
   override def dataType: DataType = StringType
 
   override def children: Seq[Expression] = inputExpressions
+
+  protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
+    copy(inputExpressions = newChildren)
+  }
 }
 
 /**
@@ -584,6 +677,7 @@ case class ST_GeometryType(inputExpressions: Seq[Expression])
   */
 case class ST_LineMerge(inputExpressions: Seq[Expression])
   extends Expression with CodegenFallback {
+  assert(inputExpressions.length == 1)
 
   // Definition of the Geometry Collection Empty
   lazy val GeometryFactory = new GeometryFactory()
@@ -592,8 +686,7 @@ case class ST_LineMerge(inputExpressions: Seq[Expression])
   override def nullable: Boolean = false
 
   override def eval(input: InternalRow): Any = {
-    assert(inputExpressions.length == 1)
-    val geometry = GeometrySerializer.deserialize(inputExpressions(0).eval(input).asInstanceOf[ArrayData])
+    val geometry = GeometrySerializer.deserialize(inputExpressions.head.eval(input).asInstanceOf[ArrayData])
 
     val merger = new LineMerger()
 
@@ -620,22 +713,21 @@ case class ST_LineMerge(inputExpressions: Seq[Expression])
   override def dataType: DataType = GeometryUDT
 
   override def children: Seq[Expression] = inputExpressions
+
+  protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
+    copy(inputExpressions = newChildren)
+  }
 }
 
 case class ST_Azimuth(inputExpressions: Seq[Expression])
   extends Expression with CodegenFallback {
+  assert(inputExpressions.length == 2)
   override def nullable: Boolean = false
 
   override def eval(input: InternalRow): Any = {
-    inputExpressions.validateLength(2)
-
-    val geometries = inputExpressions match {
-      case ArrayBuffer(point1, point2) =>
-        (point1.toGeometry(input), point2.toGeometry(input))
-    }
-
+    val geometries = (inputExpressions(0).toGeometry(input), inputExpressions(1).toGeometry(input))
     geometries match {
-      case (pointA: Point, pointB: Point) => calculateAzimuth(pointA, pointB)
+       case (pointA: Point, pointB: Point) => calculateAzimuth(pointA, pointB)
     }
   }
 
@@ -649,14 +741,19 @@ case class ST_Azimuth(inputExpressions: Seq[Expression])
   override def dataType: DataType = DoubleType
 
   override def children: Seq[Expression] = inputExpressions
+
+  protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
+    copy(inputExpressions = newChildren)
+  }
 }
 
 case class ST_X(inputExpressions: Seq[Expression])
   extends Expression with CodegenFallback {
+  assert(inputExpressions.length == 1)
+
   override def nullable: Boolean = true
 
   override def eval(input: InternalRow): Any = {
-    inputExpressions.validateLength(1)
     val geometry = inputExpressions.head.toGeometry(input)
 
     geometry match {
@@ -669,15 +766,19 @@ case class ST_X(inputExpressions: Seq[Expression])
 
   override def children: Seq[Expression] = inputExpressions
 
+  protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
+    copy(inputExpressions = newChildren)
+  }
 }
 
 
 case class ST_Y(inputExpressions: Seq[Expression])
   extends Expression with CodegenFallback {
+  assert(inputExpressions.length == 1)
+
   override def nullable: Boolean = true
 
   override def eval(input: InternalRow): Any = {
-    inputExpressions.validateLength(1)
     val geometry = inputExpressions.head.toGeometry(input)
 
     geometry match {
@@ -690,14 +791,18 @@ case class ST_Y(inputExpressions: Seq[Expression])
 
   override def children: Seq[Expression] = inputExpressions
 
+  protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
+    copy(inputExpressions = newChildren)
+  }
 }
 
 case class ST_StartPoint(inputExpressions: Seq[Expression])
   extends Expression with CodegenFallback {
+  assert(inputExpressions.length == 1)
+
   override def nullable: Boolean = true
 
   override def eval(input: InternalRow): Any = {
-    inputExpressions.validateLength(1)
     val geometry = inputExpressions.head.toGeometry(input)
     geometry match {
       case line: LineString => line.getPointN(0).toGenericArrayData
@@ -709,6 +814,9 @@ case class ST_StartPoint(inputExpressions: Seq[Expression])
 
   override def children: Seq[Expression] = inputExpressions
 
+  protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
+    copy(inputExpressions = newChildren)
+  }
 }
 
 
@@ -717,7 +825,6 @@ case class ST_Boundary(inputExpressions: Seq[Expression])
   override def nullable: Boolean = true
 
   override def eval(input: InternalRow): Any = {
-    inputExpressions.validateLength(1)
     val geometry = inputExpressions.head.toGeometry(input)
     val geometryBoundary = geometry.getBoundary
     geometryBoundary.toGenericArrayData
@@ -728,6 +835,9 @@ case class ST_Boundary(inputExpressions: Seq[Expression])
 
   override def children: Seq[Expression] = inputExpressions
 
+  protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
+    copy(inputExpressions = newChildren)
+  }
 }
 
 
@@ -738,7 +848,6 @@ case class ST_MinimumBoundingRadius(inputExpressions: Seq[Expression])
   override def nullable: Boolean = true
 
   override def eval(input: InternalRow): Any = {
-    inputExpressions.validateLength(1)
     val geometry = inputExpressions.head.toGeometry(input)
     geometry match {
       case geom: Geometry => getMinimumBoundingRadius(geom)
@@ -760,19 +869,26 @@ case class ST_MinimumBoundingRadius(inputExpressions: Seq[Expression])
   )
 
   override def children: Seq[Expression] = inputExpressions
+
+  protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
+    copy(inputExpressions = newChildren)
+  }
 }
 
 
 case class ST_MinimumBoundingCircle(inputExpressions: Seq[Expression])
   extends Expression with CodegenFallback {
+  inputExpressions.betweenLength(1, 2)
 
   override def nullable: Boolean = true
 
   override def eval(input: InternalRow): Any = {
-    inputExpressions.betweenLength(1, 2)
     val geometry = inputExpressions.head.toGeometry(input)
-    val quadrantSegments = if (inputExpressions.length == 2)
-      inputExpressions(1).toInt(input) else BufferParameters.DEFAULT_QUADRANT_SEGMENTS
+    val quadrantSegments = if (inputExpressions.length == 2) {
+      inputExpressions(1).toInt(input)
+    } else {
+      BufferParameters.DEFAULT_QUADRANT_SEGMENTS
+    }
     geometry match {
       case geom: Geometry => getMinimumBoundingCircle(geom, quadrantSegments).toGenericArrayData
       case _ => null
@@ -797,6 +913,10 @@ case class ST_MinimumBoundingCircle(inputExpressions: Seq[Expression])
   override def dataType: DataType = GeometryUDT
 
   override def children: Seq[Expression] = inputExpressions
+
+  protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
+    copy(inputExpressions = newChildren)
+  }
 }
 
 
@@ -808,12 +928,11 @@ case class ST_MinimumBoundingCircle(inputExpressions: Seq[Expression])
  */
 case class ST_LineSubstring(inputExpressions: Seq[Expression])
   extends Expression with CodegenFallback {
+  assert(inputExpressions.length == 3)
 
   override def nullable: Boolean = true
 
   override def eval(input: InternalRow): Any = {
-    inputExpressions.validateLength(3)
-
     val geometry = inputExpressions.head.toGeometry(input)
     val fractions = inputExpressions.slice(1, 3).map{
       x => x.eval(input) match {
@@ -839,6 +958,10 @@ case class ST_LineSubstring(inputExpressions: Seq[Expression])
   override def dataType: DataType = GeometryUDT
 
   override def children: Seq[Expression] = inputExpressions
+
+  protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
+    copy(inputExpressions = newChildren)
+  }
 }
 
 /**
@@ -850,14 +973,13 @@ case class ST_LineSubstring(inputExpressions: Seq[Expression])
  */
 case class ST_LineInterpolatePoint(inputExpressions: Seq[Expression])
   extends Expression with CodegenFallback {
+  assert(inputExpressions.length == 2)
 
   override def nullable: Boolean = true
 
   override def eval(input: InternalRow): Any = {
-    inputExpressions.validateLength(2)
-
-    val geometry = inputExpressions.head.toGeometry(input)
-    val fraction: Double = inputExpressions.last.eval(input) match {
+    val geometry = inputExpressions(0).toGeometry(input)
+    val fraction: Double = inputExpressions(1).eval(input) match {
       case a: Decimal => a.toDouble
       case a: Double => a
       case a: Int => a
@@ -879,6 +1001,10 @@ case class ST_LineInterpolatePoint(inputExpressions: Seq[Expression])
   override def dataType: DataType = GeometryUDT
 
   override def children: Seq[Expression] = inputExpressions
+
+  protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
+    copy(inputExpressions = newChildren)
+  }
 }
 
 
@@ -887,7 +1013,6 @@ case class ST_EndPoint(inputExpressions: Seq[Expression])
   override def nullable: Boolean = true
 
   override def eval(input: InternalRow): Any = {
-    inputExpressions.validateLength(1)
     val geometry = inputExpressions.head.toGeometry(input)
     geometry match {
       case string: LineString => string.getEndPoint.toGenericArrayData
@@ -900,6 +1025,9 @@ case class ST_EndPoint(inputExpressions: Seq[Expression])
 
   override def children: Seq[Expression] = inputExpressions
 
+  protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
+    copy(inputExpressions = newChildren)
+  }
 }
 
 case class ST_ExteriorRing(inputExpressions: Seq[Expression])
@@ -907,7 +1035,6 @@ case class ST_ExteriorRing(inputExpressions: Seq[Expression])
   override def nullable: Boolean = true
 
   override def eval(input: InternalRow): Any = {
-    inputExpressions.validateLength(1)
     val geometry = inputExpressions.head.toGeometry(input)
     geometry match {
       case polygon: Polygon => polygon.getExteriorRing.toGenericArrayData
@@ -920,17 +1047,21 @@ case class ST_ExteriorRing(inputExpressions: Seq[Expression])
 
   override def children: Seq[Expression] = inputExpressions
 
+  protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
+    copy(inputExpressions = newChildren)
+  }
 }
 
 
 case class ST_GeometryN(inputExpressions: Seq[Expression])
   extends Expression with CodegenFallback with Logging {
+  assert(inputExpressions.length == 2)
+
   override def nullable: Boolean = true
 
   override def eval(input: InternalRow): Any = {
-    inputExpressions.validateLength(2)
-    val geometry = inputExpressions.head.toGeometry(input)
-    val n = inputExpressions.tail.head.toInt(input)
+    val geometry = inputExpressions(0).toGeometry(input)
+    val n = inputExpressions(1).toInt(input)
     geometry match {
       case geom: Geometry => getNthGeom(geom, n)
       case _ => null
@@ -951,16 +1082,20 @@ case class ST_GeometryN(inputExpressions: Seq[Expression])
 
   override def children: Seq[Expression] = inputExpressions
 
+  protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
+    copy(inputExpressions = newChildren)
+  }
 }
 
 case class ST_InteriorRingN(inputExpressions: Seq[Expression])
   extends Expression with CodegenFallback {
+  assert(inputExpressions.length == 2)
+
   override def nullable: Boolean = true
 
   override def eval(input: InternalRow): Any = {
-    inputExpressions.validateLength(2)
-    val geometry = inputExpressions.head.toGeometry(input)
-    val n = inputExpressions.tail.head.toInt(input)
+    val geometry = inputExpressions(0).toGeometry(input)
+    val n = inputExpressions(1).toInt(input)
     geometry match {
       case geom: Polygon => geom.getInteriorRingN(n)
         .toGenericArrayData
@@ -971,14 +1106,19 @@ case class ST_InteriorRingN(inputExpressions: Seq[Expression])
   override def dataType: DataType = GeometryUDT
 
   override def children: Seq[Expression] = inputExpressions
+
+  protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
+    copy(inputExpressions = newChildren)
+  }
 }
 
 case class ST_Dump(inputExpressions: Seq[Expression])
   extends Expression with CodegenFallback {
+  assert(inputExpressions.length == 1)
+
   override def nullable: Boolean = true
 
   override def eval(input: InternalRow): Any = {
-    inputExpressions.validateLength(1)
     val geometry = inputExpressions.head.toGeometry(input)
     val geometryCollection = geometry match {
       case collection: GeometryCollection => {
@@ -995,14 +1135,19 @@ case class ST_Dump(inputExpressions: Seq[Expression])
   override def dataType: DataType = ArrayType(GeometryUDT)
 
   override def children: Seq[Expression] = inputExpressions
+
+  protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
+    copy(inputExpressions = newChildren)
+  }
 }
 
 case class ST_DumpPoints(inputExpressions: Seq[Expression])
   extends Expression with CodegenFallback {
+  assert(inputExpressions.length == 1)
+
   override def nullable: Boolean = true
 
   override def eval(input: InternalRow): Any = {
-    inputExpressions.validateLength(1)
     val geometry = inputExpressions.head.toGeometry(input)
     ArrayData.toArrayData(geometry.getPoints.map(geom => geom.toGenericArrayData))
   }
@@ -1010,15 +1155,20 @@ case class ST_DumpPoints(inputExpressions: Seq[Expression])
   override def dataType: DataType = ArrayType(GeometryUDT)
 
   override def children: Seq[Expression] = inputExpressions
+
+  protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
+    copy(inputExpressions = newChildren)
+  }
 }
 
 
 case class ST_IsClosed(inputExpressions: Seq[Expression])
   extends Expression with CodegenFallback {
+  assert(inputExpressions.length == 1)
+
   override def nullable: Boolean = true
 
   override def eval(input: InternalRow): Any = {
-    inputExpressions.validateLength(1)
     val geometry = inputExpressions.head.toGeometry(input)
     geometry match {
       case circle: Circle => true
@@ -1037,14 +1187,18 @@ case class ST_IsClosed(inputExpressions: Seq[Expression])
 
   override def children: Seq[Expression] = inputExpressions
 
+  protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
+    copy(inputExpressions = newChildren)
+  }
 }
 
 case class ST_NumInteriorRings(inputExpressions: Seq[Expression])
   extends Expression with CodegenFallback {
+  assert(inputExpressions.length == 1)
+
   override def nullable: Boolean = true
 
   override def eval(input: InternalRow): Any = {
-    inputExpressions.validateLength(1)
     val geometry = inputExpressions.head.toGeometry(input)
     geometry match {
       case polygon: Polygon => polygon.getNumInteriorRing
@@ -1056,16 +1210,20 @@ case class ST_NumInteriorRings(inputExpressions: Seq[Expression])
 
   override def children: Seq[Expression] = inputExpressions
 
+  protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
+    copy(inputExpressions = newChildren)
+  }
 }
 
 case class ST_AddPoint(inputExpressions: Seq[Expression])
   extends Expression with CodegenFallback {
+  inputExpressions.betweenLength(2, 3)
+
   private val geometryFactory = new GeometryFactory()
 
   override def nullable: Boolean = true
 
   override def eval(input: InternalRow): Any = {
-    inputExpressions.betweenLength(2, 3)
     val geometry = inputExpressions.head.toGeometry(input)
     val point = inputExpressions(1).toGeometry(input)
     if (inputExpressions.length == 2) addPointToGeometry(geometry, point, -1) else {
@@ -1103,17 +1261,21 @@ case class ST_AddPoint(inputExpressions: Seq[Expression])
 
   override def children: Seq[Expression] = inputExpressions
 
+  protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
+    copy(inputExpressions = newChildren)
+  }
 }
 
 case class ST_RemovePoint(inputExpressions: Seq[Expression])
   extends Expression with CodegenFallback {
+  assert(inputExpressions.length == 2)
+
   private val geometryFactory = new GeometryFactory()
 
   override def nullable: Boolean = true
 
   override def eval(input: InternalRow): Any = {
-    inputExpressions.validateLength(2)
-    val linesString = inputExpressions.head.toGeometry(input)
+    val linesString = inputExpressions(0).toGeometry(input)
     val pointToRemove = inputExpressions(1).eval(input).asInstanceOf[Int]
     linesString match {
       case string: LineString =>
@@ -1132,14 +1294,18 @@ case class ST_RemovePoint(inputExpressions: Seq[Expression])
 
   override def children: Seq[Expression] = inputExpressions
 
+  protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
+    copy(inputExpressions = newChildren)
+  }
 }
 
 case class ST_IsRing(inputExpressions: Seq[Expression])
   extends Expression with CodegenFallback {
+  assert(inputExpressions.length == 1)
+
   override def nullable: Boolean = true
 
   override def eval(input: InternalRow): Any = {
-    inputExpressions.validateLength(1)
     val geometry = inputExpressions.head.toGeometry(input)
     geometry match {
       case string: LineString => string.isSimple & string.isClosed
@@ -1150,6 +1316,10 @@ case class ST_IsRing(inputExpressions: Seq[Expression])
   override def dataType: DataType = BooleanType
 
   override def children: Seq[Expression] = inputExpressions
+
+  protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
+    copy(inputExpressions = newChildren)
+  }
 }
 
 /**
@@ -1162,17 +1332,23 @@ case class ST_IsRing(inputExpressions: Seq[Expression])
   */
 case class ST_NumGeometries(inputExpressions: Seq[Expression])
   extends Expression with CodegenFallback {
+  assert(inputExpressions.length == 1)
+
   override def nullable: Boolean = false
 
   override def eval(input: InternalRow): Any = {
-    assert(inputExpressions.length == 1)
-    val geometry = GeometrySerializer.deserialize(inputExpressions(0).eval(input).asInstanceOf[ArrayData])
+    val geometry = GeometrySerializer.deserialize(inputExpressions.head.eval(input).asInstanceOf[ArrayData])
     geometry.getNumGeometries()
   }
 
   override def dataType: DataType = IntegerType
 
+
   override def children: Seq[Expression] = inputExpressions
+
+  protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
+    copy(inputExpressions = newChildren)
+  }
 }
 
 /**
@@ -1182,10 +1358,11 @@ case class ST_NumGeometries(inputExpressions: Seq[Expression])
   */
 case class ST_FlipCoordinates(inputExpressions: Seq[Expression])
   extends Expression with CodegenFallback {
+  assert(inputExpressions.length == 1)
+
   override def nullable: Boolean = false
 
   override def eval(input: InternalRow): Any = {
-    assert(inputExpressions.length == 1)
     val geometry = GeometrySerializer.deserialize(inputExpressions(0).eval(input).asInstanceOf[ArrayData])
     GeomUtils.flipCoordinates(geometry)
     geometry.toGenericArrayData
@@ -1194,19 +1371,22 @@ case class ST_FlipCoordinates(inputExpressions: Seq[Expression])
   override def dataType: DataType = GeometryUDT
 
   override def children: Seq[Expression] = inputExpressions
+
+  protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
+    copy(inputExpressions = newChildren)
+  }
 }
 
 case class ST_SubDivide(inputExpressions: Seq[Expression])
   extends Expression with CodegenFallback {
+  assert(inputExpressions.length == 2)
+
   override def nullable: Boolean = true
 
   override def eval(input: InternalRow): Any = {
-    inputExpressions.validateLength(2)
-    val geometryRaw = inputExpressions.head
-    val maxVerticesRaw = inputExpressions(1)
-    geometryRaw.toGeometry(input) match {
+    inputExpressions(0).toGeometry(input) match {
       case geom: Geometry => ArrayData.toArrayData(
-        GeometrySubDivider.subDivide(geom, maxVerticesRaw.toInt(input)).map(_.toGenericArrayData)
+        GeometrySubDivider.subDivide(geom, inputExpressions(1).toInt(input)).map(_.toGenericArrayData)
       )
       case null => null
     }
@@ -1216,11 +1396,16 @@ case class ST_SubDivide(inputExpressions: Seq[Expression])
   override def dataType: DataType = ArrayType(GeometryUDT)
 
   override def children: Seq[Expression] = inputExpressions
+
+  protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
+    copy(inputExpressions = newChildren)
+  }
 }
 
 case class ST_SubDivideExplode(children: Seq[Expression]) extends Generator {
+  children.validateLength(2)
+
   override def eval(input: InternalRow): TraversableOnce[InternalRow] = {
-    children.validateLength(2)
     val geometryRaw = children.head
     val maxVerticesRaw = children(1)
     geometryRaw.toGeometry(input) match {
@@ -1237,16 +1422,21 @@ case class ST_SubDivideExplode(children: Seq[Expression]) extends Generator {
   }
 
   override protected def doGenCode(ctx: CodegenContext, ev: ExprCode): ExprCode = ev
+
+  protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
+    copy(children = newChildren)
+  }
 }
 
 
 case class ST_MakePolygon(inputExpressions: Seq[Expression])
   extends Expression with CodegenFallback {
+  inputExpressions.betweenLength(1, 2)
+
   override def nullable: Boolean = true
   private val geometryFactory = new GeometryFactory()
 
   override def eval(input: InternalRow): Any = {
-    inputExpressions.betweenLength(1, 2)
     val exteriorRing = inputExpressions.head
     val possibleHolesRaw = inputExpressions.tail.headOption.map(_.eval(input).asInstanceOf[ArrayData])
     val numOfElements = possibleHolesRaw.map(_.numElements()).getOrElse(0)
@@ -1280,15 +1470,20 @@ case class ST_MakePolygon(inputExpressions: Seq[Expression])
   override def dataType: DataType = GeometryUDT
 
   override def children: Seq[Expression] = inputExpressions
+
+  protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
+    copy(inputExpressions = newChildren)
+  }
 }
 
-case class ST_GeoHash(inputExpressions: Seq[Expression]) extends Expression with CodegenFallback{
+case class ST_GeoHash(inputExpressions: Seq[Expression])
+  extends Expression with CodegenFallback {
+  assert(inputExpressions.length == 2)
+
   override def nullable: Boolean = true
 
   override def eval(input: InternalRow): Any = {
-    inputExpressions.validateLength(2, Some("Please pass geometry as first argument and geohash precision"))
-
-    val geometry = inputExpressions.head.toGeometry(input)
+    val geometry = inputExpressions(0).toGeometry(input)
 
     val precision = inputExpressions(1).toInt(input)
 
@@ -1308,4 +1503,8 @@ case class ST_GeoHash(inputExpressions: Seq[Expression]) extends Expression with
   override def dataType: DataType = StringType
 
   override def children: Seq[Expression] = inputExpressions
+
+  protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
+    copy(inputExpressions = newChildren)
+  }
 }

--- a/sql/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/Predicates.scala
+++ b/sql/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/Predicates.scala
@@ -52,10 +52,14 @@ case class ST_Contains(inputExpressions: Seq[Expression])
 
     val rightGeometry = GeometrySerializer.deserialize(rightArray)
 
-    return leftGeometry.covers(rightGeometry)
+    leftGeometry.covers(rightGeometry)
   }
 
   override def dataType = BooleanType
+
+  protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
+    copy(inputExpressions = newChildren)
+  }
 }
 
 /**
@@ -82,10 +86,14 @@ case class ST_Intersects(inputExpressions: Seq[Expression])
 
     val rightGeometry = GeometrySerializer.deserialize(rightArray)
 
-    return leftGeometry.intersects(rightGeometry)
+    leftGeometry.intersects(rightGeometry)
   }
 
   override def dataType = BooleanType
+
+  protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
+    copy(inputExpressions = newChildren)
+  }
 }
 
 /**
@@ -112,10 +120,14 @@ case class ST_Within(inputExpressions: Seq[Expression])
 
     val rightGeometry = GeometrySerializer.deserialize(rightArray)
 
-    return leftGeometry.coveredBy(rightGeometry)
+    leftGeometry.coveredBy(rightGeometry)
   }
 
   override def dataType = BooleanType
+
+  protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
+    copy(inputExpressions = newChildren)
+  }
 }
 
 
@@ -126,6 +138,8 @@ case class ST_Within(inputExpressions: Seq[Expression])
   */
 case class ST_Crosses(inputExpressions: Seq[Expression])
   extends ST_Predicate with CodegenFallback {
+  assert(inputExpressions.length == 2)
+
   override def nullable: Boolean = false
 
   override def toString: String = s" **${ST_Crosses.getClass.getName}**  "
@@ -133,8 +147,6 @@ case class ST_Crosses(inputExpressions: Seq[Expression])
   override def children: Seq[Expression] = inputExpressions
 
   override def eval(inputRow: InternalRow): Any = {
-    assert(inputExpressions.length == 2)
-
     val leftArray = inputExpressions(0).eval(inputRow).asInstanceOf[ArrayData]
     val rightArray = inputExpressions(1).eval(inputRow).asInstanceOf[ArrayData]
 
@@ -142,10 +154,14 @@ case class ST_Crosses(inputExpressions: Seq[Expression])
 
     val rightGeometry = GeometrySerializer.deserialize(rightArray)
 
-    return leftGeometry.crosses(rightGeometry)
+    leftGeometry.crosses(rightGeometry)
   }
 
   override def dataType = BooleanType
+
+  protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
+    copy(inputExpressions = newChildren)
+  }
 }
 
 
@@ -173,10 +189,14 @@ case class ST_Overlaps(inputExpressions: Seq[Expression])
 
     val rightGeometry = GeometrySerializer.deserialize(rightArray)
 
-    return leftGeometry.overlaps(rightGeometry)
+    leftGeometry.overlaps(rightGeometry)
   }
 
   override def dataType = BooleanType
+
+  protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
+    copy(inputExpressions = newChildren)
+  }
 }
 
 /**
@@ -203,10 +223,14 @@ case class ST_Touches(inputExpressions: Seq[Expression])
 
     val rightGeometry = GeometrySerializer.deserialize(rightArray)
 
-    return leftGeometry.touches(rightGeometry)
+    leftGeometry.touches(rightGeometry)
   }
 
   override def dataType = BooleanType
+
+  protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
+    copy(inputExpressions = newChildren)
+  }
 }
 
 /**
@@ -237,10 +261,12 @@ case class ST_Equals(inputExpressions: Seq[Expression])
     // Returns GeometryCollection object
     val symDifference = leftGeometry.symDifference(rightGeometry)
 
-    val isEqual = symDifference.isEmpty
-
-    return isEqual
+    symDifference.isEmpty
   }
 
   override def dataType = BooleanType
+
+  protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
+    copy(inputExpressions = newChildren)
+  }
 }

--- a/sql/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/raster/Functions.scala
+++ b/sql/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/raster/Functions.scala
@@ -73,6 +73,10 @@ case class RS_NormalizedDifference(inputExpressions: Seq[Expression])
   override def dataType: DataType = ArrayType(DoubleType)
 
   override def children: Seq[Expression] = inputExpressions
+
+  protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
+    copy(inputExpressions = newChildren)
+  }
 }
 
 // Calculate mean value for a particular band
@@ -103,6 +107,10 @@ case class RS_Mean(inputExpressions: Seq[Expression])
   override def dataType: DataType = DoubleType
 
   override def children: Seq[Expression] = inputExpressions
+
+  protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
+    copy(inputExpressions = newChildren)
+  }
 }
 
 // Calculate mode of a particular band
@@ -135,6 +143,10 @@ case class RS_Mode(inputExpressions: Seq[Expression])
   override def dataType: DataType = ArrayType(DoubleType)
 
   override def children: Seq[Expression] = inputExpressions
+
+  protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
+    copy(inputExpressions = newChildren)
+  }
 }
 
 // fetch a particular region from a raster image given particular indexes(Array[minx...maxX][minY...maxY])
@@ -176,6 +188,10 @@ case class RS_FetchRegion(inputExpressions: Seq[Expression])
   override def dataType: DataType = ArrayType(DoubleType)
 
   override def children: Seq[Expression] = inputExpressions
+
+  protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
+    copy(inputExpressions = newChildren)
+  }
 }
 
 // Mark all the band values with 1 which are greater than a particular threshold
@@ -215,6 +231,10 @@ case class RS_GreaterThan(inputExpressions: Seq[Expression])
   override def dataType: DataType = ArrayType(DoubleType)
 
   override def children: Seq[Expression] = inputExpressions
+
+  protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
+    copy(inputExpressions = newChildren)
+  }
 }
 
 // Mark all the band values with 1 which are greater than or equal to a particular threshold
@@ -254,6 +274,10 @@ case class RS_GreaterThanEqual(inputExpressions: Seq[Expression])
   override def dataType: DataType = ArrayType(DoubleType)
 
   override def children: Seq[Expression] = inputExpressions
+
+  protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
+    copy(inputExpressions = newChildren)
+  }
 }
 
 // Mark all the band values with 1 which are less than a particular threshold
@@ -293,6 +317,10 @@ case class RS_LessThan(inputExpressions: Seq[Expression])
   override def dataType: DataType = ArrayType(DoubleType)
 
   override def children: Seq[Expression] = inputExpressions
+
+  protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
+    copy(inputExpressions = newChildren)
+  }
 }
 
 // Mark all the band values with 1 which are less than or equal to a particular threshold
@@ -332,6 +360,10 @@ case class RS_LessThanEqual(inputExpressions: Seq[Expression])
   override def dataType: DataType = ArrayType(DoubleType)
 
   override def children: Seq[Expression] = inputExpressions
+
+  protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
+    copy(inputExpressions = newChildren)
+  }
 }
 
 // Count number of occurences of a particular value in a band
@@ -370,6 +402,10 @@ case class RS_Count(inputExpressions: Seq[Expression])
   override def dataType: DataType = IntegerType
 
   override def children: Seq[Expression] = inputExpressions
+
+  protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
+    copy(inputExpressions = newChildren)
+  }
 }
 
 // Multiply a factor to all values of a band
@@ -407,6 +443,10 @@ case class RS_MultiplyFactor(inputExpressions: Seq[Expression])
   override def dataType: DataType = ArrayType(DoubleType)
 
   override def children: Seq[Expression] = inputExpressions
+
+  protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
+    copy(inputExpressions = newChildren)
+  }
 }
 
 // Add two bands
@@ -449,6 +489,10 @@ case class RS_AddBands(inputExpressions: Seq[Expression])
   override def dataType: DataType = ArrayType(DoubleType)
 
   override def children: Seq[Expression] = inputExpressions
+
+  protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
+    copy(inputExpressions = newChildren)
+  }
 }
 
 // Subtract two bands
@@ -490,6 +534,10 @@ case class RS_SubtractBands(inputExpressions: Seq[Expression])
   override def dataType: DataType = ArrayType(DoubleType)
 
   override def children: Seq[Expression] = inputExpressions
+
+  protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
+    copy(inputExpressions = newChildren)
+  }
 }
 
 // Multiple two bands
@@ -531,6 +579,10 @@ case class RS_MultiplyBands(inputExpressions: Seq[Expression])
   override def dataType: DataType = ArrayType(DoubleType)
 
   override def children: Seq[Expression] = inputExpressions
+
+  protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
+    copy(inputExpressions = newChildren)
+  }
 }
 
 // Divide two bands
@@ -572,6 +624,10 @@ case class RS_DivideBands(inputExpressions: Seq[Expression])
   override def dataType: DataType = ArrayType(DoubleType)
 
   override def children: Seq[Expression] = inputExpressions
+
+  protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
+    copy(inputExpressions = newChildren)
+  }
 }
 
 // Modulo of a band
@@ -609,6 +665,10 @@ case class RS_Modulo(inputExpressions: Seq[Expression])
   override def dataType: DataType = ArrayType(DoubleType)
 
   override def children: Seq[Expression] = inputExpressions
+
+  protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
+    copy(inputExpressions = newChildren)
+  }
 }
 
 // Square root of values in a band
@@ -643,6 +703,10 @@ case class RS_SquareRoot(inputExpressions: Seq[Expression])
   override def dataType: DataType = ArrayType(DoubleType)
 
   override def children: Seq[Expression] = inputExpressions
+
+  protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
+    copy(inputExpressions = newChildren)
+  }
 }
 
 // Bitwise AND between two bands
@@ -685,6 +749,10 @@ case class RS_BitwiseAnd(inputExpressions: Seq[Expression])
   override def dataType: DataType = ArrayType(DoubleType)
 
   override def children: Seq[Expression] = inputExpressions
+
+  protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
+    copy(inputExpressions = newChildren)
+  }
 }
 
 // Bitwise OR between two bands
@@ -726,6 +794,10 @@ case class RS_BitwiseOr(inputExpressions: Seq[Expression])
   override def dataType: DataType = ArrayType(DoubleType)
 
   override def children: Seq[Expression] = inputExpressions
+
+  protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
+    copy(inputExpressions = newChildren)
+  }
 }
 
 // if a value in band1 and band2 are different,value from band1 ins returned else return 0
@@ -774,6 +846,10 @@ case class RS_LogicalDifference(inputExpressions: Seq[Expression])
   override def dataType: DataType = ArrayType(DoubleType)
 
   override def children: Seq[Expression] = inputExpressions
+
+  protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
+    copy(inputExpressions = newChildren)
+  }
 }
 
 // If a value in band 1 is not equal to 0, band1 is returned else value from band2 is returned
@@ -822,6 +898,10 @@ case class RS_LogicalOver(inputExpressions: Seq[Expression])
   override def dataType: DataType = ArrayType(DoubleType)
 
   override def children: Seq[Expression] = inputExpressions
+
+  protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
+    copy(inputExpressions = newChildren)
+  }
 }
 
 case class RS_Normalize(inputExpressions: Seq[Expression])
@@ -860,6 +940,10 @@ case class RS_Normalize(inputExpressions: Seq[Expression])
   override def dataType: DataType = ArrayType(DoubleType)
 
   override def children: Seq[Expression] = inputExpressions
+
+  protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
+    copy(inputExpressions = newChildren)
+  }
 }
 
 

--- a/sql/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/raster/IO.scala
+++ b/sql/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/raster/IO.scala
@@ -119,6 +119,10 @@ case class RS_GetBand(inputExpressions: Seq[Expression])
   override def dataType: DataType = ArrayType(DoubleType)
 
   override def children: Seq[Expression] = inputExpressions
+
+  protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
+    copy(inputExpressions = newChildren)
+  }
 }
 
 case class RS_Array(inputExpressions: Seq[Expression])
@@ -147,6 +151,10 @@ case class RS_Array(inputExpressions: Seq[Expression])
   override def dataType: DataType = ArrayType(DoubleType)
 
   override def children: Seq[Expression] = inputExpressions
+
+  protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
+    copy(inputExpressions = newChildren)
+  }
 }
 
 case class RS_Base64(inputExpressions: Seq[Expression])
@@ -223,6 +231,10 @@ case class RS_Base64(inputExpressions: Seq[Expression])
   override def dataType: DataType = StringType
 
   override def children: Seq[Expression] = inputExpressions
+
+  protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
+    copy(inputExpressions = newChildren)
+  }
 }
 
 case class RS_HTML(inputExpressions: Seq[Expression])
@@ -252,5 +264,9 @@ case class RS_HTML(inputExpressions: Seq[Expression])
   override def dataType: DataType = StringType
 
   override def children: Seq[Expression] = inputExpressions
+
+  protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
+    copy(inputExpressions = newChildren)
+  }
 }
 

--- a/sql/src/main/scala/org/apache/spark/sql/sedona_sql/strategy/join/BroadcastIndexJoinExec.scala
+++ b/sql/src/main/scala/org/apache/spark/sql/sedona_sql/strategy/join/BroadcastIndexJoinExec.scala
@@ -127,4 +127,8 @@ case class BroadcastIndexJoinExec(left: SparkPlan,
       }.filter(boundCondition(_))
     }
   }
+
+  protected def withNewChildrenInternal(newLeft: SparkPlan, newRight: SparkPlan): SparkPlan = {
+    copy(left = newLeft, right = newRight)
+  }
 }

--- a/sql/src/main/scala/org/apache/spark/sql/sedona_sql/strategy/join/BroadcastIndexJoinExec.scala
+++ b/sql/src/main/scala/org/apache/spark/sql/sedona_sql/strategy/join/BroadcastIndexJoinExec.scala
@@ -28,7 +28,8 @@ import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{Attribute, BindReferences, Expression, Predicate, UnsafeRow}
 import org.apache.spark.sql.catalyst.expressions.codegen.GenerateUnsafeRowJoiner
 import org.apache.spark.sql.catalyst.plans.physical.Partitioning
-import org.apache.spark.sql.execution.{BinaryExecNode, SparkPlan}
+import org.apache.spark.sql.execution.SparkPlan
+import org.apache.spark.sql.sedona_sql.execution.SedonaBinaryExecNode
 import org.locationtech.jts.geom.Geometry
 import org.locationtech.jts.index.SpatialIndex
 
@@ -40,7 +41,7 @@ case class BroadcastIndexJoinExec(left: SparkPlan,
                                   intersects: Boolean,
                                   extraCondition: Option[Expression] = None,
                                   radius: Option[Expression] = None)
-  extends BinaryExecNode
+  extends SedonaBinaryExecNode
     with TraitJoinQueryBase
     with Logging {
 

--- a/sql/src/main/scala/org/apache/spark/sql/sedona_sql/strategy/join/DistanceJoinExec.scala
+++ b/sql/src/main/scala/org/apache/spark/sql/sedona_sql/strategy/join/DistanceJoinExec.scala
@@ -25,7 +25,8 @@ import org.apache.spark.internal.Logging
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.expressions.{BindReferences, Expression, UnsafeRow}
 import org.apache.spark.sql.catalyst.util.ArrayData
-import org.apache.spark.sql.execution.{BinaryExecNode, SparkPlan}
+import org.apache.spark.sql.execution.SparkPlan
+import org.apache.spark.sql.sedona_sql.execution.SedonaBinaryExecNode
 import org.locationtech.jts.geom.Geometry
 
 // ST_Distance(left, right) <= radius
@@ -37,7 +38,7 @@ case class DistanceJoinExec(left: SparkPlan,
                             radius: Expression,
                             intersects: Boolean,
                             extraCondition: Option[Expression] = None)
-  extends BinaryExecNode
+  extends SedonaBinaryExecNode
     with TraitJoinQueryExec
     with Logging {
 

--- a/sql/src/main/scala/org/apache/spark/sql/sedona_sql/strategy/join/DistanceJoinExec.scala
+++ b/sql/src/main/scala/org/apache/spark/sql/sedona_sql/strategy/join/DistanceJoinExec.scala
@@ -65,4 +65,8 @@ case class DistanceJoinExec(left: SparkPlan,
     spatialRdd
   }
 
+  protected def withNewChildrenInternal(newLeft: SparkPlan, newRight: SparkPlan): SparkPlan = {
+    copy(left = newLeft, right = newRight)
+  }
+
 }

--- a/sql/src/main/scala/org/apache/spark/sql/sedona_sql/strategy/join/RangeJoinExec.scala
+++ b/sql/src/main/scala/org/apache/spark/sql/sedona_sql/strategy/join/RangeJoinExec.scala
@@ -42,4 +42,9 @@ case class RangeJoinExec(left: SparkPlan,
                          extraCondition: Option[Expression] = None)
   extends BinaryExecNode
     with TraitJoinQueryExec
-    with Logging {}
+    with Logging {
+
+  protected def withNewChildrenInternal(newLeft: SparkPlan, newRight: SparkPlan): SparkPlan = {
+    copy(left = newLeft, right = newRight)
+  }
+}

--- a/sql/src/main/scala/org/apache/spark/sql/sedona_sql/strategy/join/RangeJoinExec.scala
+++ b/sql/src/main/scala/org/apache/spark/sql/sedona_sql/strategy/join/RangeJoinExec.scala
@@ -20,7 +20,8 @@ package org.apache.spark.sql.sedona_sql.strategy.join
 
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.expressions.Expression
-import org.apache.spark.sql.execution.{BinaryExecNode, SparkPlan}
+import org.apache.spark.sql.execution.SparkPlan
+import org.apache.spark.sql.sedona_sql.execution.SedonaBinaryExecNode
 
 /**
   * ST_Contains(left, right) - left contains right
@@ -40,7 +41,7 @@ case class RangeJoinExec(left: SparkPlan,
                          rightShape: Expression,
                          intersects: Boolean,
                          extraCondition: Option[Expression] = None)
-  extends BinaryExecNode
+  extends SedonaBinaryExecNode
     with TraitJoinQueryExec
     with Logging {
 

--- a/sql/src/main/scala/org/apache/spark/sql/sedona_sql/strategy/join/SpatialIndexExec.scala
+++ b/sql/src/main/scala/org/apache/spark/sql/sedona_sql/strategy/join/SpatialIndexExec.scala
@@ -58,4 +58,8 @@ case class SpatialIndexExec(child: SparkPlan,
     spatialRDD.buildIndex(indexType, false)
     sparkContext.broadcast(spatialRDD.indexedRawRDD.take(1).asScala.head).asInstanceOf[Broadcast[T]]
   }
+
+  protected def withNewChildInternal(newChild: SparkPlan): SparkPlan = {
+    copy(child = newChild)
+  }
 }

--- a/sql/src/main/scala/org/apache/spark/sql/sedona_sql/strategy/join/SpatialIndexExec.scala
+++ b/sql/src/main/scala/org/apache/spark/sql/sedona_sql/strategy/join/SpatialIndexExec.scala
@@ -26,15 +26,15 @@ import org.apache.spark.internal.Logging
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{Attribute, BindReferences, Expression, UnsafeRow}
-import org.apache.spark.sql.execution.{SparkPlan, UnaryExecNode}
-
+import org.apache.spark.sql.execution.SparkPlan
+import org.apache.spark.sql.sedona_sql.execution.SedonaUnaryExecNode
 
 
 case class SpatialIndexExec(child: SparkPlan,
                             shape: Expression,
                             indexType: IndexType,
                             radius: Option[Expression] = None)
-  extends UnaryExecNode
+  extends SedonaUnaryExecNode
     with TraitJoinQueryBase
     with Logging {
 

--- a/viz/src/main/scala/org/apache/sedona/viz/sql/UDF/UdfRegistrator.scala
+++ b/viz/src/main/scala/org/apache/sedona/viz/sql/UDF/UdfRegistrator.scala
@@ -19,6 +19,7 @@
 package org.apache.sedona.viz.sql.UDF
 
 import org.apache.spark.sql.catalyst.FunctionIdentifier
+import org.apache.spark.sql.catalyst.expressions.ExpressionInfo
 import org.apache.spark.sql.{SQLContext, SparkSession}
 
 object UdfRegistrator {
@@ -28,7 +29,18 @@ object UdfRegistrator {
   }
 
   def registerAll(sparkSession: SparkSession): Unit = {
-    Catalog.expressions.foreach(f => sparkSession.sessionState.functionRegistry.createOrReplaceTempFunction(f.getClass.getSimpleName.dropRight(1), f))
+    Catalog.expressions.foreach(f => {
+      val functionIdentifier = FunctionIdentifier(f.getClass.getSimpleName.dropRight(1))
+      val expressionInfo = new ExpressionInfo(
+        f.getClass.getCanonicalName,
+        functionIdentifier.database.orNull,
+        functionIdentifier.funcName)
+      sparkSession.sessionState.functionRegistry.registerFunction(
+        functionIdentifier,
+        expressionInfo,
+        f
+      )
+    })
     Catalog.aggregateExpressions.foreach(f => sparkSession.udf.register(f.getClass.getSimpleName, f))
   }
 

--- a/viz/src/main/scala/org/apache/sedona/viz/sql/UDF/UdfRegistrator.scala
+++ b/viz/src/main/scala/org/apache/sedona/viz/sql/UDF/UdfRegistrator.scala
@@ -29,8 +29,7 @@ object UdfRegistrator {
   }
 
   def registerAll(sparkSession: SparkSession): Unit = {
-    val catalog = org.apache.sedona.sql.UDF.Catalog.expressions ++ Catalog.expressions
-    catalog.foreach(f => {
+    Catalog.expressions.foreach(f => {
       val functionIdentifier = FunctionIdentifier(f.getClass.getSimpleName.dropRight(1))
       val expressionInfo = new ExpressionInfo(
         f.getClass.getCanonicalName,

--- a/viz/src/main/scala/org/apache/sedona/viz/sql/UDF/UdfRegistrator.scala
+++ b/viz/src/main/scala/org/apache/sedona/viz/sql/UDF/UdfRegistrator.scala
@@ -29,7 +29,8 @@ object UdfRegistrator {
   }
 
   def registerAll(sparkSession: SparkSession): Unit = {
-    Catalog.expressions.foreach(f => {
+    val catalog = org.apache.sedona.sql.UDF.Catalog.expressions ++ Catalog.expressions
+    catalog.foreach(f => {
       val functionIdentifier = FunctionIdentifier(f.getClass.getSimpleName.dropRight(1))
       val expressionInfo = new ExpressionInfo(
         f.getClass.getCanonicalName,

--- a/viz/src/main/scala/org/apache/spark/sql/sedona_viz/expressions/Colorize.scala
+++ b/viz/src/main/scala/org/apache/spark/sql/sedona_viz/expressions/Colorize.scala
@@ -30,10 +30,10 @@ import org.beryx.awt.color.ColorFactory
 
 case class ST_Colorize(inputExpressions: Seq[Expression])
   extends Expression with CodegenFallback with Logging {
+  assert(inputExpressions.length <= 3)
   override def nullable: Boolean = false
 
   override def eval(input: InternalRow): Any = {
-    assert(inputExpressions.length <= 3)
     if (inputExpressions.length == 3) {
       // This means the user wants to apply the same color to everywhere
       // Fetch the color from the third input string
@@ -62,4 +62,8 @@ case class ST_Colorize(inputExpressions: Seq[Expression])
   override def dataType: DataType = IntegerType
 
   override def children: Seq[Expression] = inputExpressions
+
+  protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
+    copy(inputExpressions = newChildren)
+  }
 }

--- a/viz/src/main/scala/org/apache/spark/sql/sedona_viz/expressions/ImageEncoder.scala
+++ b/viz/src/main/scala/org/apache/spark/sql/sedona_viz/expressions/ImageEncoder.scala
@@ -32,10 +32,10 @@ import org.apache.spark.unsafe.types.UTF8String
 
 case class ST_EncodeImage(inputExpressions: Seq[Expression])
   extends Expression with CodegenFallback {
+  assert(inputExpressions.length == 1)
   override def nullable: Boolean = false
 
   override def eval(input: InternalRow): Any = {
-    assert(inputExpressions.length == 1)
     val inputArray = inputExpressions(0).eval(input).asInstanceOf[ArrayData]
     val serializer = new ImageWrapperSerializer
     val image = serializer.readImage(inputArray.toByteArray()).getImage
@@ -47,4 +47,8 @@ case class ST_EncodeImage(inputExpressions: Seq[Expression])
   override def dataType: DataType = StringType
 
   override def children: Seq[Expression] = inputExpressions
+
+  protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
+    copy(inputExpressions = newChildren)
+  }
 }

--- a/viz/src/main/scala/org/apache/spark/sql/sedona_viz/expressions/Partitioner.scala
+++ b/viz/src/main/scala/org/apache/spark/sql/sedona_viz/expressions/Partitioner.scala
@@ -29,10 +29,10 @@ import org.apache.spark.unsafe.types.UTF8String
 
 case class ST_TileName(inputExpressions: Seq[Expression])
   extends Expression with CodegenFallback {
+  assert(inputExpressions.length == 2)
   override def nullable: Boolean = false
 
   override def eval(input: InternalRow): Any = {
-    assert(inputExpressions.length == 2)
     val inputArray = inputExpressions(0).eval(input).asInstanceOf[ArrayData]
     val zoomLevel = inputExpressions(1).eval(input).asInstanceOf[Int]
     val partPerAxis = Math.pow(2, zoomLevel).intValue()
@@ -45,4 +45,8 @@ case class ST_TileName(inputExpressions: Seq[Expression])
   override def dataType: DataType = StringType
 
   override def children: Seq[Expression] = inputExpressions
+
+  protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
+    copy(inputExpressions = newChildren)
+  }
 }

--- a/viz/src/main/scala/org/apache/spark/sql/sedona_viz/expressions/Pixelize.scala
+++ b/viz/src/main/scala/org/apache/spark/sql/sedona_viz/expressions/Pixelize.scala
@@ -35,11 +35,10 @@ import org.locationtech.jts.geom._
 
 case class ST_Pixelize(inputExpressions: Seq[Expression])
   extends Expression with CodegenFallback with Logging {
-
+  assert(inputExpressions.length <= 5)
   override def toString: String = s" **${ST_Pixelize.getClass.getName}**  "
 
   override def eval(input: InternalRow): Any = {
-    assert(inputExpressions.length <= 5)
     val inputGeometry = GeometrySerializer.deserialize(inputExpressions(0).eval(input).asInstanceOf[ArrayData])
     val resolutionX = inputExpressions(1).eval(input).asInstanceOf[Integer]
     val resolutionY = inputExpressions(2).eval(input).asInstanceOf[Integer]
@@ -93,4 +92,8 @@ case class ST_Pixelize(inputExpressions: Seq[Expression])
   override def children: Seq[Expression] = inputExpressions
 
   override def nullable: Boolean = false
+
+  protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
+    copy(inputExpressions = newChildren)
+  }
 }

--- a/viz/src/main/scala/org/apache/spark/sql/sedona_viz/expressions/Render.scala
+++ b/viz/src/main/scala/org/apache/spark/sql/sedona_viz/expressions/Render.scala
@@ -113,6 +113,6 @@ case class ST_Render() extends UserDefinedAggregateFunction with Logging {
     for (i <- xArray.indices) {
       bufferedImage.setRGB(xArray(i), yArray(i), colorArray(i))
     }
-    return new ImageSerializableWrapper(bufferedImage)
+    new ImageSerializableWrapper(bufferedImage)
   }
 }

--- a/viz/src/test/scala/org/apache/sedona/viz/sql/standardVizOperatorTest.scala
+++ b/viz/src/test/scala/org/apache/sedona/viz/sql/standardVizOperatorTest.scala
@@ -29,47 +29,41 @@ class standardVizOperatorTest extends TestBaseScala {
     it("Generate a single image") {
       spark.sql(
         """
-          |CREATE OR REPLACE TEMP VIEW pixels AS
           |SELECT pixel, shape FROM pointtable
           |LATERAL VIEW EXPLODE(ST_Pixelize(shape, 256, 256, ST_PolygonFromEnvelope(-126.790180,24.863836,-64.630926,50.000)) ) AS pixel
-        """.stripMargin)
+        """.stripMargin).createOrReplaceTempView("pixels")
       spark.sql(
         """
-          |CREATE OR REPLACE TEMP VIEW pixelaggregates AS
           |SELECT pixel, count(*) as weight
           |FROM pixels
           |GROUP BY pixel
-        """.stripMargin)
+        """.stripMargin).createOrReplaceTempView("pixelaggregates")
       spark.sql(
         """
-          |CREATE OR REPLACE TEMP VIEW images AS
           |SELECT ST_Render(pixel, ST_Colorize(weight, (SELECT max(weight) FROM pixelaggregates), 'red')) AS image
           |FROM pixelaggregates
-        """.stripMargin)
+        """.stripMargin).createOrReplaceTempView("images")
       var image = spark.table("images").take(1)(0)(0).asInstanceOf[ImageSerializableWrapper].getImage
       var imageGenerator = new ImageGenerator
       imageGenerator.SaveRasterImageAsLocalFile(image, System.getProperty("user.dir")+"/target/points", ImageType.PNG)
-      spark.sql(
+      val imageString = spark.sql(
         """
-          |CREATE OR REPLACE TEMP VIEW imagestring AS
           |SELECT ST_EncodeImage(image)
           |FROM images
         """.stripMargin)
-      spark.table("imagestring").show(1)
+      imageString.show(1)
     }
 
     it("Generate a single image using a fat query") {
       spark.sql(
         """
-          |CREATE OR REPLACE TEMP VIEW boundtable AS
           |SELECT ST_Envelope_Aggr(shape) as bound FROM pointtable
-        """.stripMargin)
+        """.stripMargin).createOrReplaceTempView("boundtable")
       spark.sql(
         """
-          |CREATE OR REPLACE TEMP VIEW pixels AS
           |SELECT pixel, shape FROM pointtable
           |LATERAL VIEW EXPLODE(ST_Pixelize(ST_Transform(ST_FlipCoordinates(shape), 'epsg:4326','epsg:3857'), 256, 256, (SELECT ST_Transform(ST_FlipCoordinates(bound), 'epsg:4326','epsg:3857') FROM boundtable))) AS pixel
-        """.stripMargin)
+        """.stripMargin).createOrReplaceTempView("pixels")
       spark.sql(
         """
           |CREATE OR REPLACE TEMP VIEW pixelaggregates AS
@@ -77,22 +71,20 @@ class standardVizOperatorTest extends TestBaseScala {
           |FROM pixels
           |GROUP BY pixel
         """.stripMargin)
-      spark.sql(
+      val images = spark.sql(
         """
-          |CREATE OR REPLACE TEMP VIEW images AS
           |SELECT ST_EncodeImage(ST_Render(pixel, ST_Colorize(weight, (SELECT max(weight) FROM pixelaggregates)))) AS image, (SELECT ST_AsText(bound) FROM boundtable) AS boundary
           |FROM pixelaggregates
         """.stripMargin)
-      spark.table("images").show(1)
+      images.show(1)
     }
 
     it("Passed the pipeline on points") {
       spark.sql(
         """
-          |CREATE OR REPLACE TEMP VIEW pixels AS
           |SELECT pixel, shape FROM pointtable
           |LATERAL VIEW EXPLODE(ST_Pixelize(shape, 1000, 800, ST_PolygonFromEnvelope(-126.790180,24.863836,-64.630926,50.000))) AS pixel
-        """.stripMargin)
+        """.stripMargin).createOrReplaceTempView("pixels")
       spark.sql(
         """
           |CREATE OR REPLACE TEMP VIEW pixelaggregates AS
@@ -107,10 +99,9 @@ class standardVizOperatorTest extends TestBaseScala {
     it("Passed the pipeline on polygons") {
       spark.sql(
         """
-          |CREATE OR REPLACE TEMP VIEW pixels AS
           |SELECT pixel, rate, shape FROM usdata
           |LATERAL VIEW EXPLODE(ST_Pixelize(shape, 1000, 1000, ST_PolygonFromEnvelope(-126.790180,24.863836,-64.630926,50.000))) AS pixel
-        """.stripMargin)
+        """.stripMargin).createOrReplaceTempView("pixels")
       spark.sql(
         """
           |CREATE OR REPLACE TEMP VIEW pixelaggregates AS
@@ -118,16 +109,10 @@ class standardVizOperatorTest extends TestBaseScala {
           |FROM pixels
           |GROUP BY pixel
         """.stripMargin)
-      spark.sql(
+      val imageDf = spark.sql(
         """
-          |CREATE OR REPLACE TEMP VIEW images AS
           |SELECT ST_Render(pixel, ST_Colorize(weight, (SELECT max(weight) FROM pixelaggregates))) AS image
           |FROM pixelaggregates
-        """.stripMargin)
-      var imageDf = spark.sql(
-        """
-          |SELECT image
-          |FROM images
         """.stripMargin)
       var image = imageDf.take(1)(0)(0).asInstanceOf[ImageSerializableWrapper].getImage
       var imageGenerator = new ImageGenerator
@@ -138,10 +123,9 @@ class standardVizOperatorTest extends TestBaseScala {
       var zoomLevel = 2
       spark.sql(
         """
-          |CREATE OR REPLACE TEMP VIEW pixels AS
           |SELECT pixel, shape FROM pointtable
           |LATERAL VIEW EXPLODE(ST_Pixelize(shape, 1000, 1000, ST_PolygonFromEnvelope(-126.790180,24.863836,-64.630926,50.000))) AS pixel
-        """.stripMargin)
+        """.stripMargin).createOrReplaceTempView("pixels")
       spark.sql(
         """
           |CREATE OR REPLACE TEMP VIEW pixelaggregates AS
@@ -151,18 +135,16 @@ class standardVizOperatorTest extends TestBaseScala {
         """.stripMargin)
       spark.sql(
         s"""
-          |CREATE OR REPLACE TEMP VIEW pixel_weights AS
           |SELECT pixel, weight, ST_TileName(pixel, $zoomLevel) AS pid
           |FROM pixelaggregates
-        """.stripMargin)
-      spark.sql(
+        """.stripMargin).createOrReplaceTempView("pixel_weights")
+      val images = spark.sql(
         s"""
-          |CREATE OR REPLACE TEMP VIEW images AS
           |SELECT ST_Render(pixel, ST_Colorize(weight, (SELECT max(weight) FROM pixelaggregates)), $zoomLevel) AS image
           |FROM pixel_weights
           |GROUP BY pid
-        """.stripMargin).explain()
-      spark.table("images").show(1)
+        """.stripMargin)
+      images.show(1)
     }
   }
 }


### PR DESCRIPTION
## Is this PR related to a proposed Issue?
https://issues.apache.org/jira/browse/SEDONA-67

## What changes were proposed in this PR?
Adds support for Spark 3.2, but maintains compatibilities.

Specifically to get 3.2 working I had to:
- Rework how functions are registered to use an API present in all supported versions of Spark.
- Add `withNewChildrenInternal` to all expressions. Without using `override`, it works both in the new version to override it as well as in older versions it's just ignored.
- Add a new profile for Spark 3.2 because it needs a newer version of jackson to test with

Additionally I cleaned up a few things:
- Removed assert statements from the eval method of expressions. This is an analysis time check that can be done on instantiation of the case class
- Removed a bunch of return statements to make things consistent

## How was this patch tested?
Existing tests, though I do need help figuring out how the github workflow should be updated.

## Did this PR include necessary documentation updates?
Haven't looked at the documentation yet, probably need to update a compatibility page still