### PR TITLE
[SEDONA-73] Add support for Scala 2.13 build

### DIFF
--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -23,6 +23,9 @@ jobs:
             scala: 2.11.8
           - spark: 3.0.3
             scala: 2.11.8
+        include:
+          - spark: 3.2.0
+            scala: 2.13.5
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: true
       matrix:
         spark: [2.4.8, 3.0.3, 3.1.2, 3.2.0]
-        scala: [2.11.8, 2.12.8]
+        scala: [2.11.8, 2.12.15]
         r: [oldrel, release]
         exclude:
           - spark: 3.2.0
@@ -38,10 +38,10 @@ jobs:
             scala: 2.11.8
             r: release
           - spark: 2.4.8
-            scala: 2.12.8
+            scala: 2.12.15
             r: oldrel
           - spark: 2.4.8
-            scala: 2.12.8
+            scala: 2.12.15
             r: release
     env:
       SPARK_VERSION: ${{ matrix.spark }}

--- a/pom.xml
+++ b/pom.xml
@@ -218,6 +218,11 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>org.scala-lang.modules</groupId>
+            <artifactId>scala-collection-compat_${scala.compat.version}</artifactId>
+            <version>2.5.0</version>
+        </dependency>
         <!-- Test -->
         <dependency>
             <groupId>junit</groupId>
@@ -545,6 +550,21 @@
                 <spark.converter.version>spark2</spark.converter.version>
                 <jackson.version>2.6.7</jackson.version>
                 <maven.deploy.skip>true</maven.deploy.skip>
+            </properties>
+        </profile>
+        <profile>
+            <id>scala2.13</id>
+            <activation>
+                <property>
+                    <name>scala</name>
+                    <value>2.13</value>
+                </property>
+                <activeByDefault>false</activeByDefault>
+            </activation>
+            <properties>
+                <scala.version>2.13.5</scala.version>
+                <scala.compat.version>2.13</scala.compat.version>
+                <scaladoc.arg>-no-java-comments</scaladoc.arg>
             </properties>
         </profile>
         <profile>

--- a/python-adapter/src/main/scala/org.apache.sedona.python.wrapper/adapters/EnvelopeAdapter.scala
+++ b/python-adapter/src/main/scala/org.apache.sedona.python.wrapper/adapters/EnvelopeAdapter.scala
@@ -23,7 +23,7 @@ import net.razorvine.pickle.Unpickler
 import net.razorvine.pickle.objects.ClassDict
 import org.locationtech.jts.geom.Envelope
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 object EnvelopeAdapter {
   def getFromPython(bytes: Array[Byte]): java.util.List[Envelope] = {

--- a/python-adapter/src/main/scala/org.apache.sedona.python.wrapper/adapters/PythonConverter.scala
+++ b/python-adapter/src/main/scala/org.apache.sedona.python.wrapper/adapters/PythonConverter.scala
@@ -23,7 +23,7 @@ import org.apache.sedona.python.wrapper.translation.{FlatPairRddConverter, Geome
 import org.apache.spark.api.java.{JavaPairRDD, JavaRDD}
 import org.locationtech.jts.geom.Geometry
 
-import scala.collection.convert.Wrappers.SeqWrapper
+import scala.jdk.CollectionConverters._
 
 object PythonConverter extends GeomSerializer {
 
@@ -39,6 +39,6 @@ object PythonConverter extends GeomSerializer {
   def translatePythonRDDToJava(pythonRDD: JavaRDD[Array[Byte]]): JavaRDD[Geometry] =
     PythonRDDToJavaConverter(pythonRDD, geometrySerializer).translateToJava
 
-  def translateGeometrySeqToPython(spatialData: SeqWrapper[Geometry]): Array[Array[Byte]] =
-    GeometrySeqToPythonConverter(spatialData, geometrySerializer).translateToPython
+  def translateGeometrySeqToPython(spatialData: java.util.List[Geometry]): Array[Array[Byte]] =
+    GeometrySeqToPythonConverter(spatialData.asScala.toSeq, geometrySerializer).translateToPython
 }

--- a/python-adapter/src/main/scala/org.apache.sedona.python.wrapper/translation/GeometrySeqToPythonConverter.scala
+++ b/python-adapter/src/main/scala/org.apache.sedona.python.wrapper/translation/GeometrySeqToPythonConverter.scala
@@ -22,7 +22,7 @@ package org.apache.sedona.python.wrapper.translation
 import org.apache.sedona.python.wrapper.utils.implicits._
 import org.locationtech.jts.geom.Geometry
 
-case class GeometrySeqToPythonConverter(spatialData: scala.collection.convert.Wrappers.SeqWrapper[Geometry],
+case class GeometrySeqToPythonConverter(spatialData: Seq[Geometry],
                                         geometrySerializer: PythonGeometrySerializer) {
 
   def translateToPython: Array[Array[Byte]] = {

--- a/python-adapter/src/main/scala/org.apache.sedona.python.wrapper/utils/PythonAdapterWrapper.scala
+++ b/python-adapter/src/main/scala/org.apache.sedona.python.wrapper/utils/PythonAdapterWrapper.scala
@@ -24,17 +24,17 @@ import org.apache.spark.api.java.JavaPairRDD
 import org.apache.spark.sql.{DataFrame, SparkSession}
 import org.locationtech.jts.geom.Geometry
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 object PythonAdapterWrapper {
   def toDf[T <: Geometry](spatialRDD: SpatialRDD[T], fieldNames: java.util.ArrayList[String], sparkSession: SparkSession): DataFrame = {
-    Adapter.toDf(spatialRDD, fieldNames.asScala, sparkSession)
+    Adapter.toDf(spatialRDD, fieldNames.asScala.toSeq, sparkSession)
   }
 
   def toDf(spatialPairRDD: JavaPairRDD[Geometry, Geometry],
            leftFieldnames: java.util.ArrayList[String],
            rightFieldNames: java.util.ArrayList[String],
            sparkSession: SparkSession): DataFrame = {
-    Adapter.toDf(spatialPairRDD, leftFieldnames.asScala, rightFieldNames.asScala, sparkSession)
+    Adapter.toDf(spatialPairRDD, leftFieldnames.asScala.toSeq, rightFieldNames.asScala.toSeq, sparkSession)
   }
 }

--- a/python-adapter/src/test/scala/org/apache/sedona/python/wrapper/GeometrySample.scala
+++ b/python-adapter/src/test/scala/org/apache/sedona/python/wrapper/GeometrySample.scala
@@ -21,8 +21,7 @@ package org.apache.sedona.python.wrapper
 
 import org.locationtech.jts.geom.Geometry
 
-import java.io.FileInputStream
-import scala.tools.nsc.interpreter.InputStream
+import java.io.{FileInputStream, InputStream}
 import scala.io.Source
 
 trait GeometrySample extends PythonTestSpec {

--- a/python-adapter/src/test/scala/org/apache/sedona/python/wrapper/TestToPythonSerialization.scala
+++ b/python-adapter/src/test/scala/org/apache/sedona/python/wrapper/TestToPythonSerialization.scala
@@ -23,7 +23,7 @@ import org.apache.sedona.python.wrapper.translation.{FlatPairRddConverter, Geome
 import org.apache.spark.api.java.JavaPairRDD
 import org.scalatest.Matchers
 import org.apache.sedona.python.wrapper.utils.implicits._
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 
 class TestToPythonSerialization extends SparkUtil with GeometrySample with Matchers {

--- a/sql/src/main/scala/org/apache/sedona/sql/SedonaSqlExtensions.scala
+++ b/sql/src/main/scala/org/apache/sedona/sql/SedonaSqlExtensions.scala
@@ -26,7 +26,7 @@ class SedonaSqlExtensions extends (SparkSessionExtensions => Unit) {
   def apply(e: SparkSessionExtensions): Unit = {
     e.injectCheckRule(spark => {
       SedonaSQLRegistrator.registerAll(spark)
-      _ => Unit
+      _ => ()
     })
   }
 }

--- a/sql/src/main/scala/org/apache/sedona/sql/utils/Adapter.scala
+++ b/sql/src/main/scala/org/apache/sedona/sql/utils/Adapter.scala
@@ -57,8 +57,8 @@ object Adapter {
   def toSpatialRdd(dataFrame: DataFrame, geometryFieldName: String, fieldNames: Seq[String]): SpatialRDD[Geometry] = {
     var spatialRDD = new SpatialRDD[Geometry]
     spatialRDD.rawSpatialRDD = toRdd(dataFrame, geometryFieldName).toJavaRDD()
-    import scala.collection.JavaConversions._
-    if (fieldNames != null && fieldNames.nonEmpty) spatialRDD.fieldNames = fieldNames
+    import scala.jdk.CollectionConverters._
+    if (fieldNames != null && fieldNames.nonEmpty) spatialRDD.fieldNames = fieldNames.asJava
     else spatialRDD.fieldNames = null
     spatialRDD
   }
@@ -81,8 +81,8 @@ object Adapter {
   def toSpatialRdd(dataFrame: DataFrame, geometryColId: Int, fieldNames: Seq[String]): SpatialRDD[Geometry] = {
     var spatialRDD = new SpatialRDD[Geometry]
     spatialRDD.rawSpatialRDD = toRdd(dataFrame, geometryColId).toJavaRDD()
-    import scala.collection.JavaConversions._
-    if (fieldNames.nonEmpty) spatialRDD.fieldNames = fieldNames
+    import scala.jdk.CollectionConverters._
+    if (fieldNames.nonEmpty) spatialRDD.fieldNames = fieldNames.asJava
     else spatialRDD.fieldNames = null
     spatialRDD
   }
@@ -107,7 +107,7 @@ object Adapter {
   }
 
   def toDf[T <: Geometry](spatialRDD: SpatialRDD[T], sparkSession: SparkSession): DataFrame = {
-    import scala.collection.JavaConverters._
+    import scala.jdk.CollectionConverters._
     if (spatialRDD.fieldNames != null) return toDf(spatialRDD, spatialRDD.fieldNames.asScala.toList, sparkSession)
     toDf(spatialRDD, null, sparkSession);
   }

--- a/sql/src/main/scala/org/apache/spark/sql/sedona_sql/strategy/join/SpatialIndexExec.scala
+++ b/sql/src/main/scala/org/apache/spark/sql/sedona_sql/strategy/join/SpatialIndexExec.scala
@@ -18,7 +18,7 @@
  */
 package org.apache.spark.sql.sedona_sql.strategy.join
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 import org.apache.sedona.core.enums.IndexType
 import org.apache.spark.broadcast.Broadcast

--- a/sql/src/test/scala/org/apache/sedona/sql/GeometrySample.scala
+++ b/sql/src/test/scala/org/apache/sedona/sql/GeometrySample.scala
@@ -23,8 +23,7 @@ import org.apache.spark.sql.{Dataset, Row}
 import org.locationtech.jts.geom.Geometry
 import org.locationtech.jts.io.WKTReader
 
-import java.io.FileInputStream
-import scala.tools.nsc.interpreter.InputStream
+import java.io.{FileInputStream, InputStream}
 
 
 trait GeometrySample {

--- a/sql/src/test/scala/org/apache/sedona/sql/adapterTestScala.scala
+++ b/sql/src/test/scala/org/apache/sedona/sql/adapterTestScala.scala
@@ -136,8 +136,8 @@ class adapterTestScala extends TestBaseScala with GivenWhenThen{
       assert(joinResultDf.schema(1).dataType == GeometryUDT)
       assert(joinResultDf.schema(0).name == "leftgeometry")
       assert(joinResultDf.schema(1).name == "rightgeometry")
-      import scala.collection.JavaConversions._
-      val joinResultDf2 = Adapter.toDf(joinResultPairRDD, polygonRDD.fieldNames, List(), sparkSession)
+      import scala.jdk.CollectionConverters._
+      val joinResultDf2 = Adapter.toDf(joinResultPairRDD, polygonRDD.fieldNames.asScala.toSeq, List(), sparkSession)
       assert(joinResultDf2.schema(0).dataType == GeometryUDT)
       assert(joinResultDf2.schema(0).name == "leftgeometry")
       assert(joinResultDf2.schema(1).name == "abc")
@@ -194,7 +194,7 @@ class adapterTestScala extends TestBaseScala with GivenWhenThen{
       val HDFDataVariableList:Array[String] = Array("LST", "QC", "Error_LST", "Emis_31", "Emis_32")
       val earthdataHDFPoint = new EarthdataHDFPointMapper(HDFincrement, HDFoffset, HDFrootGroupName, HDFDataVariableList, HDFDataVariableName, urlPrefix)
       val spatialRDD = new PointRDD(sparkSession.sparkContext, InputLocation, numPartitions, earthdataHDFPoint, StorageLevel.MEMORY_ONLY)
-      import scala.collection.JavaConverters._
+      import scala.jdk.CollectionConverters._
       spatialRDD.fieldNames = HDFDataVariableList.dropRight(4).toList.asJava
       val spatialDf = Adapter.toDf(spatialRDD, sparkSession)
       assert(spatialDf.schema.fields(1).name == "LST")

--- a/sql/src/test/scala/org/apache/sedona/sql/functions/TestStSubDivide.scala
+++ b/sql/src/test/scala/org/apache/sedona/sql/functions/TestStSubDivide.scala
@@ -25,9 +25,8 @@ import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.prop.{TableDrivenPropertyChecks, TableFor3, TableFor4}
 
-import java.io.FileInputStream
+import java.io.{FileInputStream, InputStream}
 import scala.io.Source
-import scala.tools.nsc.interpreter.InputStream
 
 
 class TestStSubDivide extends AnyFunSuite with Matchers with TableDrivenPropertyChecks with FunctionsHelper {

--- a/sql/src/test/scala/org/apache/sedona/sql/rasteralgebraTest.scala
+++ b/sql/src/test/scala/org/apache/sedona/sql/rasteralgebraTest.scala
@@ -75,7 +75,7 @@ class rasteralgebraTest extends TestBaseScala with BeforeAndAfter with GivenWhen
     it("Passed RS_Mode") {
       val inputDf = Seq((Seq(200.0, 400.0, 600.0, 200.0)), (Seq(200.0, 400.0, 600.0, 700.0))).toDF("Band")
       val expectedResult = List(List(200.0), List(200.0, 400.0, 600.0, 700.0))
-      val actualResult = inputDf.selectExpr("RS_Mode(Band) as mode").as[List[Double]].collect().toList
+      val actualResult = inputDf.selectExpr("sort_array(RS_Mode(Band)) as mode").as[List[Double]].collect().toList
       val resultList = actualResult zip expectedResult
       for((actual, expected) <- resultList) {
         assert(actual == expected)

--- a/viz/src/main/scala/org/apache/sedona/viz/sql/SedonaVizExtensions.scala
+++ b/viz/src/main/scala/org/apache/sedona/viz/sql/SedonaVizExtensions.scala
@@ -26,7 +26,7 @@ class SedonaVizExtensions extends (SparkSessionExtensions => Unit) {
   def apply(e: SparkSessionExtensions): Unit = {
     e.injectCheckRule(spark => {
       SedonaVizRegistrator.registerAll(spark)
-      _ => Unit
+      _ => ()
     })
   }
 }

--- a/viz/src/main/scala/org/apache/sedona/viz/sql/operator/VizPartitioner.scala
+++ b/viz/src/main/scala/org/apache/sedona/viz/sql/operator/VizPartitioner.scala
@@ -26,7 +26,7 @@ import org.apache.spark.sql.functions._
 import org.apache.spark.sql.{DataFrame, Row}
 import org.locationtech.jts.geom.{Envelope, Geometry}
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.collection.mutable.ArrayBuffer
 
 object VizPartitioner {
@@ -75,7 +75,7 @@ object VizPartitioner {
           currentValues(secondIdPos) = LineageDecoder(secondaryZone.lineage)
           // Assign primary id
           currentValues(primaryIdPos) = LineageDecoder(secondaryZone.lineage.take(zoomLevel))
-          list += Row.fromSeq(currentValues)
+          list += Row.fromSeq(currentValues.toSeq)
         })
       }
       list.iterator

--- a/viz/src/main/scala/org/apache/spark/sql/sedona_viz/expressions/Pixelize.scala
+++ b/viz/src/main/scala/org/apache/spark/sql/sedona_viz/expressions/Pixelize.scala
@@ -77,7 +77,7 @@ case class ST_Pixelize(inputExpressions: Seq[Expression])
       }
     }
     assert(pixels.size() > 0)
-    import scala.collection.JavaConverters._
+    import scala.jdk.CollectionConverters._
     return new GenericArrayData(pixels.asScala.map(f=> {
       val out = new ByteArrayOutputStream()
       val kryo = new Kryo()


### PR DESCRIPTION
## Is this PR related to a proposed Issue?
https://issues.apache.org/jira/browse/SEDONA-73

## What changes were proposed in this PR?
Adds a Scala 2.13 Maven profile and updates the code base to support 2.13 in addition to existing versions. A new dependency was added that provides backward compatibility for various Java-Scala conversion utilities. I enabled the Java tests to also run with 2.13.

It will be a little trickier to figure out how to run the Python or R tests with Scala 2.13, because I think both just download official releases to do it. It looks like there are official releases for Scala 2.13, but I am not trying to tackle that in this PR. The Python tests would likely have to be updated to download the official release versus installing from Pypi, because that only comes with the default Scala version. This is mostly for experimental purposes, and for making any new additions be Scala 2.13 compatible to make the release in the future easier. 

I also did a little refactoring on the raster functions that I missed last time. They were double eval'ing everything to check the type. I updated to just use the common parent type instead to convert to a double array.

## How was this patch tested?
Existing tests, added 2.13 build to java GitHub workflow tests.

## Did this PR include necessary documentation updates?
Internal update right now, can update documentation when creating official 2.13 release support.
