### PR TITLE
[DOCS] Fix typo in Raster & Databricks doc

### DIFF
--- a/docs/api/sql/Raster-operators.md
+++ b/docs/api/sql/Raster-operators.md
@@ -24,7 +24,7 @@ Since: `v1.1.0`
 Spark SQL example:
 ```Scala
 
-val subtractDF = spark.sql("select RS_Subtract(band1, band2) as differenceOfOfBands from dataframe")
+val subtractDF = spark.sql("select RS_SubtractBands(band1, band2) as differenceOfOfBands from dataframe")
 
 ```
 

--- a/docs/setup/databricks.md
+++ b/docs/setup/databricks.md
@@ -105,7 +105,7 @@ spark.kryo.registrator org.apache.sedona.core.serde.SedonaKryoRegistrator
 
 From your cluster configuration (`Cluster` -> `Edit` -> `Configuration` -> `Advanced options` -> `Init Scripts`) add the newly created init script 
 ```
-/dbfs/FileStore/sedona/sedona-init.sh
+dbfs:/FileStore/sedona/sedona-init.sh
 ```
 
 *Note: You need to install the sedona libraries via init script because the libraries installed via UI are installed after the cluster has already started, and therefore the classes specified by the config `spark.sql.extensions`, `spark.serializer`, and `spark.kryo.registrator` are not available at startup time.*


### PR DESCRIPTION
In the Databricks doc, I think the path to the init script should be prefixed with `dbfs:` as opposed to a directory in the local file system. After this change on my Azure Databricks cluster, the init script executed successfully.

## Is this PR related to a proposed Issue?
No

## What changes were proposed in this PR?
Document update

## How was this patch tested?
Fix tested on an Azure Databricks cluster

## Did this PR include necessary documentation updates?
Yes
