### PR TITLE
[SEDONA-73][FOLLOWUP] Exclude scala-library from scala-collection-compat

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -216,6 +216,12 @@
             <groupId>org.scala-lang.modules</groupId>
             <artifactId>scala-collection-compat_${scala.compat.version}</artifactId>
             <version>2.5.0</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.scala-lang</groupId>
+                    <artifactId>scala-library</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <!-- Test -->
         <dependency>


### PR DESCRIPTION
## Is this PR related to a proposed Issue?
Follow up to https://issues.apache.org/jira/browse/SEDONA-73, exclude scala-library from the new dependency.

## What changes were proposed in this PR?
Dependency update

## How was this patch tested?
Existing tests

## Did this PR include necessary documentation updates?
