### PR TITLE
[CI] Fix docs GitHub CI by updating fontawesome name

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,7 +16,7 @@ jobs:
         fetch-depth: 0
     - uses: actions/setup-python@v2
       with:
-        python-version: 3.7
+        python-version: 3.x
     - run: pip install mkdocs-material
     - run: pip install mkdocs-macros-plugin
     - run: pip install mkdocs-git-revision-date-localized-plugin

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,7 +16,7 @@ jobs:
         fetch-depth: 0
     - uses: actions/setup-python@v2
       with:
-        python-version: 3.x
+        python-version: 3.10
     - run: pip install mkdocs-material
     - run: pip install mkdocs-macros-plugin
     - run: pip install mkdocs-git-revision-date-localized-plugin

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,7 +16,7 @@ jobs:
         fetch-depth: 0
     - uses: actions/setup-python@v2
       with:
-        python-version: 3.10
+        python-version: 3.7
     - run: pip install mkdocs-material
     - run: pip install mkdocs-macros-plugin
     - run: pip install mkdocs-git-revision-date-localized-plugin

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -118,7 +118,7 @@ theme:
     accent: 'green'
   favicon: https://www.apache.org/logos/res/sedona/sedona.png
   icon:
-    logo: fontawesome/solid/globe-americas
+    logo: fontawesome/solid/earth-americas
     repo: fontawesome/brands/github
   font:
     text: Lato


### PR DESCRIPTION
## Is this PR related to a proposed Issue?

Fix the failed DOCS CI which is caused by the name changing in fontawesome: https://fontawesome.com/docs/web/setup/upgrade/whats-changed#icons-renamed-in-version-6

## What changes were proposed in this PR?

## How was this patch tested?

## Did this PR include necessary documentation updates?
