### PR TITLE
[SEDONA-89] GeometryUDT equals should test equivalence of the other object

### DIFF
--- a/sql/src/main/scala/org/apache/spark/sql/sedona_sql/UDT/GeometryUDT.scala
+++ b/sql/src/main/scala/org/apache/spark/sql/sedona_sql/UDT/GeometryUDT.scala
@@ -51,7 +51,7 @@ class GeometryUDT extends UserDefinedType[Geometry] {
   }
 
   override def equals(other: Any): Boolean = other match {
-    case _: UserDefinedType[_] => isInstanceOf[GeometryUDT]
+    case _: UserDefinedType[_] => other.isInstanceOf[GeometryUDT]
     case _ => false
   }
 


### PR DESCRIPTION
## Is this PR related to a proposed Issue?

https://issues.apache.org/jira/browse/SEDONA-89

## What changes were proposed in this PR?

`GeometryUDT.equals` currently returns true for **any** UDT, not just other geometry

## How was this patch tested?

Internally with another project.

## Did this PR include necessary documentation updates?

No APIs change in any appreciable way.
