### PR TITLE
[SEDONA-96] Refactor ST_MakeValid to use GeometryFixer.

### DIFF
--- a/docs/api/sql/Function.md
+++ b/docs/api/sql/Function.md
@@ -162,27 +162,40 @@ FROM polygondf
 
 ## ST_MakeValid
 
-Introduction: Given an invalid polygon or multipolygon and removeHoles boolean flag,
- create a valid representation of the geometry.
+Introduction: Given an invalid geometry, create a valid representation of the geometry.
 
-Format: `ST_MakeValid (A:geometry, removeHoles:Boolean)`
+Collapsed geometries are either converted to empty (keepCollaped=true) or a valid geometry of lower dimension (keepCollapsed=false).
+Default is keepCollapsed=false.
+
+Format: `ST_MakeValid (A:geometry)`
+
+Format: `ST_MakeValid (A:geometry, keepCollapsed:Boolean)`
 
 Since: `v1.0.0`
 
 Spark SQL example:
 
 ```SQL
-SELECT geometryValid.polygon
-FROM table
-LATERAL VIEW ST_MakeValid(polygon, false) geometryValid AS polygon
+WITH linestring AS (
+    SELECT ST_GeomFromWKT('LINESTRING(1 1, 1 1)') AS geom
+) SELECT ST_MakeValid(geom), ST_MakeValid(geom, true) FROM linestring
+```
+
+Result:
+```
++------------------+------------------------+
+|st_makevalid(geom)|st_makevalid(geom, true)|
++------------------+------------------------+
+|  LINESTRING EMPTY|             POINT (1 1)|
++------------------+------------------------+
 ```
 
 !!!note
-    Might return multiple polygons from a only one invalid polygon
-    That's the reason why we need to use the LATERAL VIEW expression
-    
-!!!note
-    Throws an exception if the geometry isn't polygon or multipolygon
+    In Sedona up to and including version 1.2 the behaviour of ST_MakeValid was different.
+    Be sure to check you code when upgrading. 
+    The previous implementation only worked for (multi)polygons and had a different interpretation of the second, boolean, argument.
+    It would also sometimes return multiple geometries for a single geomtry input.
+
 
 ## ST_PrecisionReduce
 

--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
         <geotools.version>24.0</geotools.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <dependency.scope>provided</dependency.scope>
-        <jts.version>1.18.0</jts.version>
+        <jts.version>1.18.2</jts.version>
         <jts2geojson.version>0.16.1</jts2geojson.version>
     </properties>
 

--- a/sql/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/Functions.scala
+++ b/sql/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/Functions.scala
@@ -35,6 +35,7 @@ import org.apache.spark.unsafe.types.UTF8String
 import org.geotools.geometry.jts.JTS
 import org.geotools.referencing.CRS
 import org.locationtech.jts.algorithm.MinimumBoundingCircle
+import org.locationtech.jts.geom.util.GeometryFixer
 import org.locationtech.jts.geom.{PrecisionModel, _}
 import org.locationtech.jts.io.{ByteOrderValues, WKBWriter, WKTWriter}
 import org.locationtech.jts.linearref.LengthIndexedLine
@@ -342,48 +343,37 @@ case class ST_Intersection(inputExpressions: Seq[Expression])
 }
 
 /**
-  * Given an invalid polygon or multipolygon and removeHoles boolean flag, create a valid representation of the geometry
+  * Given an invalid geometry, create a valid representation of the geometry.
+  * See: http://lin-ear-th-inking.blogspot.com/2021/05/fixing-invalid-geometry-with-jts.html
   *
   * @param inputExpressions
   */
 case class ST_MakeValid(inputExpressions: Seq[Expression])
-  extends Generator with CodegenFallback with UserDataGeneratator {
-  assert(inputExpressions.length == 2)
+  extends Expression with CodegenFallback {
+  assert(inputExpressions.length == 1 || inputExpressions.length == 2)
 
-  override def elementSchema: StructType = new StructType().add("Geometry", new GeometryUDT)
-
-  override def toString: String = s" **${ST_MakeValid.getClass.getName}** "
-
-  override def eval(input: InternalRow): TraversableOnce[InternalRow] = {
-    val geometry = GeometrySerializer.deserialize(inputExpressions(0).eval(input).asInstanceOf[ArrayData])
-    val removeHoles = inputExpressions(1).eval(input).asInstanceOf[Boolean]
-
-    // in order to do flatMap on java collections(util.List[Polygon])
-    import scala.jdk.CollectionConverters._
-
-    // makeValid works only on polygon or multipolygon
-    if (!geometry.getGeometryType.equalsIgnoreCase("POLYGON") && !geometry.getGeometryType.equalsIgnoreCase("MULTIPOLYGON")) {
-      throw new IllegalArgumentException("ST_MakeValid works only on Polygons and MultiPolygons")
+  override def eval(input: InternalRow): Any = {
+    val geometry = inputExpressions.head.toGeometry(input)
+    val keepCollapsed = if (inputExpressions.length == 2) {
+      inputExpressions(1).eval(input).asInstanceOf[Boolean]
+    } else {
+      false
     }
-
-    val validGeometry = geometry match {
-      case g: MultiPolygon =>
-        (0 until g.getNumGeometries).flatMap(i => {
-          val polygon = g.getGeometryN(i).asInstanceOf[Polygon]
-          JTS.makeValid(polygon, removeHoles).asScala.iterator
-        })
-      case g: Polygon =>
-        JTS.makeValid(g, removeHoles).asScala.iterator
-      case _ => Nil
+    (geometry) match {
+      case (geometry: Geometry) => nullSafeEval(geometry, keepCollapsed)
+      case _ => null
     }
-
-    val result = validGeometry.map(g => {
-      val serializedGeometry = GeometrySerializer.serialize(g.asInstanceOf[Geometry])
-      InternalRow(new GenericArrayData(serializedGeometry))
-    })
-
-    result
   }
+
+  private def nullSafeEval(geometry: Geometry, keepCollapsed: Boolean) = {
+    val fixer = new GeometryFixer(geometry)
+    fixer.setKeepCollapsed(keepCollapsed)
+    fixer.getResult.toGenericArrayData
+  }
+
+  override def nullable: Boolean = true
+
+  override def dataType: DataType = GeometryUDT
 
   override def children: Seq[Expression] = inputExpressions
 


### PR DESCRIPTION
I will always return a single geometry and works for all geometry types.

## Is this PR related to a proposed Issue?

[SEDONA-96](https://issues.apache.org/jira/browse/SEDONA-96)

## What changes were proposed in this PR?

Refactor ST_MakeValid to use GeometryFixer in JTS

## How was this patch tested?

Unit tests added

## Did this PR include necessary documentation updates?

Yes
