### PR TITLE
[SEDONA-118] Using the within function of JTS for ST_Within

### DIFF
--- a/sql/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/Predicates.scala
+++ b/sql/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/Predicates.scala
@@ -17,7 +17,6 @@
  * under the License.
  */
 package org.apache.spark.sql.sedona_sql.expressions
-
 import org.apache.sedona.sql.utils.GeometrySerializer
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.Expression
@@ -108,7 +107,7 @@ case class ST_Within(inputExpressions: Seq[Expression])
   // This is a binary expression
   assert(inputExpressions.length == 2)
 
-  override def toString: String = s" **${ST_Intersects.getClass.getName}**  "
+  override def toString: String = s" **${ST_Within.getClass.getName}**  "
 
   override def children: Seq[Expression] = inputExpressions
 
@@ -120,7 +119,7 @@ case class ST_Within(inputExpressions: Seq[Expression])
 
     val rightGeometry = GeometrySerializer.deserialize(rightArray)
 
-    leftGeometry.coveredBy(rightGeometry)
+    leftGeometry.within(rightGeometry)
   }
 
   override def dataType = BooleanType

--- a/sql/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/Predicates.scala
+++ b/sql/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/Predicates.scala
@@ -17,6 +17,7 @@
  * under the License.
  */
 package org.apache.spark.sql.sedona_sql.expressions
+
 import org.apache.sedona.sql.utils.GeometrySerializer
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.Expression


### PR DESCRIPTION

## Did you read the Contributor Guide?

- Yes, I have read [Contributor Rules](https://sedona.apache.org/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/community/develop/)

## Is this PR related to a JIRA ticket?

- Yes, the URL of the assoicated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-118. The PR name follows the format `[SEDONA-118] my subject`.


## What changes were proposed in this PR?
Changing the JTS method called during ST_Within evaluation from coveredBy to within

## How was this patch tested?
It was ensured that for the affected query:
`ST_Within(ST_GeomFromWKT('POINT(0 0)'),ST_GeomFromWKT('POLYGON ((0.0 0.0, 10.0 0.0, 10.0 10.0, 0.0 10.0, 0.0 0.0))')) `
The correct value (false) is returned. 

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the docs.
