### PR TITLE
[SEDONA-127] Add null safety to ST_GeomFromWKT/WKB/Text

### DIFF
--- a/sql/src/test/scala/org/apache/sedona/sql/constructorTestScala.scala
+++ b/sql/src/test/scala/org/apache/sedona/sql/constructorTestScala.scala
@@ -67,6 +67,8 @@ class constructorTestScala extends TestBaseScala {
       polygonWktDf.createOrReplaceTempView("polygontable")
       var polygonDf = sparkSession.sql("select ST_GeomFromWkt(polygontable._c0) as countyshape from polygontable")
       assert(polygonDf.count() == 100)
+      val nullGeom = sparkSession.sql("select ST_GeomFromWKT(null)")
+      assert(nullGeom.first().isNullAt(0))
     }
 
     it("Passed ST_LineFromText") {
@@ -98,6 +100,8 @@ class constructorTestScala extends TestBaseScala {
       polygonWktDf.createOrReplaceTempView("polygontable")
       var polygonDf = sparkSession.sql("select ST_GeomFromText(polygontable._c0) as countyshape from polygontable")
       assert(polygonDf.count() == 100)
+      val nullGeom = sparkSession.sql("select ST_GeomFromText(null)")
+      assert(nullGeom.first().isNullAt(0))
     }
 
     it("Passed ST_GeomFromWKT multipolygon read as polygon bug") {
@@ -126,6 +130,9 @@ class constructorTestScala extends TestBaseScala {
       val geometries = sparkSession.sql("SELECT ST_GeomFromWKB(rawWKBTable.wkb) as countyshape from rawWKBTable")
       val expectedGeom = "LINESTRING (-2.1047439575195312 -0.354827880859375, -1.49606454372406 -0.6676061153411865)";
       assert(geometries.first().getAs[Geometry](0).toString.equals(expectedGeom))
+      // null input
+      val nullGeom = sparkSession.sql("SELECT ST_GeomFromWKB(null)")
+      assert(nullGeom.first().isNullAt(0))
     }
 
     it("Passed ST_GeomFromGeoJSON") {


### PR DESCRIPTION

## Did you read the Contributor Guide?

- Yes, I have read [Contributor Rules](https://sedona.apache.org/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/community/develop/)


## Is this PR related to a JIRA ticket?

- Yes, the URL of the assoicated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-127. The PR name follows the format `[SEDONA-XXX] my subject`.

## What changes were proposed in this PR?

This PR adds null safety to ST_GeomFromWKB, ST_GeomFromWKT and ST_GeomFromTest

## How was this patch tested?

Unit tests added

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the docs.
