### PR TITLE
[SEDONA-123] Fix check for invalid latitude/longitude values in ST_GeoHash

### DIFF
--- a/sql/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/geohash/GeometryGeoHashEncoder.scala
+++ b/sql/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/geohash/GeometryGeoHashEncoder.scala
@@ -24,7 +24,9 @@ object GeometryGeoHashEncoder {
   private val geometryFactory = new GeometryFactory()
   def calculate(geom: Geometry, precision: Int): Option[String] = {
     val gbox = geom.getEnvelope.getEnvelopeInternal
-    if (gbox.getMinX < -180 || gbox.getMinY < -90 || gbox.getMaxX > 180 || gbox.getMaxX > 90) None
+    // Latitude can take values in [-90, 90]
+    // Longitude can take values in [-180, 180]
+    if (gbox.getMinX < -180 || gbox.getMinY < -90 || gbox.getMaxX > 180 || gbox.getMaxY > 90) None
     else {
       val lon = gbox.getMinX + (gbox.getMaxX - gbox.getMinX) / 2
       val lat = gbox.getMinY + (gbox.getMaxY - gbox.getMinY) / 2


### PR DESCRIPTION

## Did you read the Contributor Guide?

- Yes, I have read [Contributor Rules](https://sedona.apache.org/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/community/develop/)

## Is this PR related to a JIRA ticket?

- Yes, the URL of the assoicated JIRA ticket is <https://issues.apache.org/jira/browse/SEDONA-123>. The PR name follows the format `[SEDONA-XXX] my subject`.

## What changes were proposed in this PR?

Currently, ST_GeoHash checks for invalid latitude and longitude values (in `GeometryGeoHashEncoder.scala`):

- Longitude < -180
- Latitude < -90
- Longitude > 180
- *Longitude* > 90

This PR fixes the last comparison to check latitude instead of longitude.

## How was this patch tested?

Added unit tests that fail before the fix (as well as some passing tests for similar boundary cases), implemented the fix suggested by Itamar, and tests now pass again.

Some screenshots during the process:

Test results after adding tests but before fix:

<img width="1648" alt="Tests before overall" src="https://user-images.githubusercontent.com/51218458/175780052-8195d89c-2ea1-4a6c-80cf-59deca4a20e2.png">

<img width="1648" alt="Tests before specific" src="https://user-images.githubusercontent.com/51218458/175780055-cfa5dbbb-7856-4b80-8f56-ee4ae186784d.png">

Test results after fix:

<img width="1648" alt="Tests after" src="https://user-images.githubusercontent.com/51218458/175780063-d71f4de8-83a1-4ac7-9bae-46a175cd21ab.png">

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the docs.
