### PR TITLE
[DOCS] fix dbplyr integration test failures

### DIFF
--- a/R/tests/testthat/test-dbplyr-integration.R
+++ b/R/tests/testthat/test-dbplyr-integration.R
@@ -71,7 +71,7 @@ test_that("ST_Buffer() works as expected", {
       dbplyr::remote_query(),
     sprintf(
       "SELECT `id`, ST_Buffer(`pt`, CAST(3 AS DOUBLE)) AS `pt`\nFROM `%s`",
-      sdf$ops$x$x
+      dbplyr::remote_name(sdf)
     ) %>%
       dbplyr::sql()
   )
@@ -115,7 +115,7 @@ test_that("ST_SimplifyPreserveTopology() works as expected", {
       dbplyr::remote_query(),
     sprintf(
       "SELECT `id`, ST_SimplifyPreserveTopology(`pt`, CAST(1 AS DOUBLE)) AS `pt`\nFROM `%s`",
-      sdf$ops$x$x
+      dbplyr::remote_name(sdf)
     ) %>%
       dbplyr::sql()
   )


### PR DESCRIPTION
Signed-off-by: Yitao Li <yitaoli@apache.org>



## Did you read the Contributor Guide?

- Yes, I have read [Contributor Rules](https://sedona.apache.org/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/community/develop/)

- No, I haven't read it.

## Is this PR related to a JIRA ticket?

- Yes, the URL of the assoicated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-XXX. The PR name follows the format `[SEDONA-XXX] my subject`.


## What changes were proposed in this PR?

Fixing one failing test case in R

## How was this patch tested?

`TESTTHAT_FILTER='sdf-interface' SPARK_VERSION='2.4.8' NOT_CRAN='true' Rscript testthat.R --testthat`

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the docs.
