### PR TITLE
[DOCS] Fix Python tests which randomly fails

### DIFF
--- a/python/tests/streaming/spark/test_constructor_functions.py
+++ b/python/tests/streaming/spark/test_constructor_functions.py
@@ -1,5 +1,5 @@
 import os
-import random
+import uuid
 from typing import List, Any, Optional
 
 import pytest
@@ -305,7 +305,7 @@ class TestConstructorFunctions(TestBase):
         ).selectExpr(f"{function_name}({', '.join(arguments)}) AS result")
 
         # and target table
-        random_table_name = f"view_{random.randint(0, 100000)}"
+        random_table_name = f"view_{uuid.uuid4().hex}"
 
         # when saving stream to memory
         streaming_query = input_stream.writeStream.format("memory") \


### PR DESCRIPTION

## Did you read the Contributor Guide?

- Yes, I have read [Contributor Rules](https://sedona.apache.org/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/community/develop/)

## Is this PR related to a JIRA ticket?


- No, this is a documentation update. The PR name follows the format `[DOCS] my subject`.


## What changes were proposed in this PR?

The random tables names in Python tests occasionally fail due to duplicate table names. This PR uses UUID to replace random table names.

## How was this patch tested?


## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the docs.
