### PR TITLE
[SEDONA-127] Follow up on previous commit adding null safety to ST_Ge…

### DIFF
--- a/sql/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/Constructors.scala
+++ b/sql/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/Constructors.scala
@@ -181,7 +181,7 @@ case class ST_GeomFromWKT(inputExpressions: Seq[Expression])
         var formatMapper = new FormatMapper(fileDataSplitter, false)
         formatMapper.readGeometry(geomString.toString).toGenericArrayData
       }
-      case _ => null
+      case null => null
     }
   }
 
@@ -214,7 +214,7 @@ case class ST_GeomFromText(inputExpressions: Seq[Expression])
         var formatMapper = new FormatMapper(fileDataSplitter, false)
         formatMapper.readGeometry(geomString.toString).toGenericArrayData
       }
-      case _ => null
+      case null => null
     }
   }
 
@@ -252,7 +252,7 @@ case class ST_GeomFromWKB(inputExpressions: Seq[Expression])
         // convert raw wkb byte array to geometry
         new WKBReader().read(wkb).toGenericArrayData
       }
-      case _ => null
+      case null => null
     }
   }
 

--- a/sql/src/test/scala/org/apache/sedona/sql/constructorTestScala.scala
+++ b/sql/src/test/scala/org/apache/sedona/sql/constructorTestScala.scala
@@ -69,6 +69,10 @@ class constructorTestScala extends TestBaseScala {
       assert(polygonDf.count() == 100)
       val nullGeom = sparkSession.sql("select ST_GeomFromWKT(null)")
       assert(nullGeom.first().isNullAt(0))
+      // Fail on wrong input type
+      intercept[Exception] {
+        sparkSession.sql("SELECT ST_GeomFromWKT(0)").collect()
+      }
     }
 
     it("Passed ST_LineFromText") {
@@ -102,6 +106,10 @@ class constructorTestScala extends TestBaseScala {
       assert(polygonDf.count() == 100)
       val nullGeom = sparkSession.sql("select ST_GeomFromText(null)")
       assert(nullGeom.first().isNullAt(0))
+      // Fail on wrong input type
+      intercept[Exception] {
+        sparkSession.sql("SELECT ST_GeomFromText(0)").collect()
+      }
     }
 
     it("Passed ST_GeomFromWKT multipolygon read as polygon bug") {
@@ -133,6 +141,10 @@ class constructorTestScala extends TestBaseScala {
       // null input
       val nullGeom = sparkSession.sql("SELECT ST_GeomFromWKB(null)")
       assert(nullGeom.first().isNullAt(0))
+      // Fail on wrong input type
+      intercept[Exception] {
+        sparkSession.sql("SELECT ST_GeomFromWKB(0)").collect()
+      }
     }
 
     it("Passed ST_GeomFromGeoJSON") {


### PR DESCRIPTION
…omFromWKT/WKB/Text.

The previous commit was a bit to lax when checking input types.
Any input that's not recognized would return null. Now null is explicitly checked.



## Did you read the Contributor Guide?

- Yes, I have read [Contributor Rules](https://sedona.apache.org/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/community/develop/)

## Is this PR related to a JIRA ticket?

- Yes, the URL of the assoicated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-127. The PR name follows the format `[SEDONA-127] my subject`.


## What changes were proposed in this PR?

This is a follow up on SEDONA-127 (merged but not released).
The previous commit introduced null safety but accidentally allowed wrong input types to be treated as null.
E.g. ST_GeomFromText(0) should fail instead of returning null.

## How was this patch tested?

Tests added

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the docs.
