### PR TITLE
[SEDONA-136] Enable testAsEWKT for Flink

### DIFF
--- a/flink/src/test/java/org/apache/sedona/flink/FunctionTest.java
+++ b/flink/src/test/java/org/apache/sedona/flink/FunctionTest.java
@@ -138,6 +138,7 @@ public class FunctionTest extends TestBase{
         Assert.assertEquals("LINEARRING (-0.5 -0.5, -0.5 0.5, 0.5 0.5, 0.5 -0.5, -0.5 -0.5)", linearRing.toString());
     }
 
+    @Test
     public void testAsEWKT() {
         Table polygonTable = createPolygonTable(testDataSize);
         polygonTable = polygonTable.select(call(Functions.ST_AsEWKT.class.getSimpleName(), $(polygonColNames[0])));


### PR DESCRIPTION

## Did you read the Contributor Guide?

- Yes, I have read [Contributor Rules](https://sedona.apache.org/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/community/develop/)

## Is this PR related to a JIRA ticket?

- Yes, the URL of the assoicated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-136. The PR name follows the format `[SEDONA-XXX] my subject`.

## What changes were proposed in this PR?

This PR enables testAsEWKT for Flink again, which was accidentally disabled before.

## How was this patch tested?

Ran `mvn test -pl flink` locally and confirmed the number of tests executed was incremented.

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the docs.
