### PR TITLE
[SEDONA-137] Fix ST_Buffer for Flink to work

### DIFF
--- a/flink/src/main/java/org/apache/sedona/flink/expressions/Functions.java
+++ b/flink/src/main/java/org/apache/sedona/flink/expressions/Functions.java
@@ -37,7 +37,8 @@ import static org.locationtech.jts.geom.Coordinate.NULL_ORDINATE;
 public class Functions {
     public static class ST_Buffer extends ScalarFunction {
         @DataTypeHint(value = "RAW", bridgedTo = org.locationtech.jts.geom.Geometry.class)
-        public Geometry eval(Object o, @DataTypeHint("Double") Double radius) {
+        public Geometry eval(@DataTypeHint(value = "RAW", bridgedTo = org.locationtech.jts.geom.Geometry.class)
+                Object o, @DataTypeHint("Double") Double radius) {
             Geometry geom = (Geometry) o;
             return geom.buffer(radius);
         }

--- a/flink/src/test/java/org/apache/sedona/flink/FunctionTest.java
+++ b/flink/src/test/java/org/apache/sedona/flink/FunctionTest.java
@@ -39,6 +39,14 @@ public class FunctionTest extends TestBase{
     }
 
     @Test
+    public void testBuffer() {
+        Table pointTable = createPointTable_real(testDataSize);
+        Table bufferTable = pointTable.select(call(Functions.ST_Buffer.class.getSimpleName(), $(pointColNames[0]), 1));
+        Geometry result = (Geometry) first(bufferTable).getField(0);
+        assert(result instanceof Polygon);
+    }
+
+    @Test
     public void testFlipCoordinates() {
         Table pointTable = createPointTable_real(testDataSize);
         Table flippedTable = pointTable.select(call(Functions.ST_FlipCoordinates.class.getSimpleName(), $(pointColNames[0])));


### PR DESCRIPTION

## Did you read the Contributor Guide?

- Yes, I have read [Contributor Rules](https://sedona.apache.org/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/community/develop/)

## Is this PR related to a JIRA ticket?

- Yes, the URL of the assoicated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-137. The PR name follows the format `[SEDONA-XXX] my subject`.

## What changes were proposed in this PR?

Currently, the ST_Buffer function for Flink is broken. This PR fixes it.

## How was this patch tested?

Ran `mvn test -pl flink` locally and ensured all tests passed including the new one.

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the docs.
