### PR TITLE
[DOCS] Arrange items in the API reference in alphabetical order

### DIFF
--- a/docs/api/flink/Constructor.md
+++ b/docs/api/flink/Constructor.md
@@ -1,29 +1,28 @@
-## ST_Point
+## ST_GeomFromGeoHash
 
-Introduction: Construct a Point from X and Y
+Introduction: Create Geometry from geohash string and optional precision
 
-Format: `ST_Point (X:decimal, Y:decimal)`
+Format: `ST_GeomFromGeoHash(geohash: string, precision: int)`
 
 Since: `v1.2.1`
 
 SQL example:
 ```SQL
-SELECT ST_Point(x, y) AS pointshape
-FROM pointtable
+SELECT ST_GeomFromGeoHash('s00twy01mt', 4) AS geom
 ```
 
-## ST_GeomFromWKT
+## ST_GeomFromGeoJSON
 
-Introduction: Construct a Geometry from Wkt
+Introduction: Construct a Geometry from GeoJson
 
-Format:
-`ST_GeomFromWKT (Wkt:string)`
+Format: `ST_GeomFromGeoJSON (GeoJson:string)`
 
 Since: `v1.2.0`
 
 SQL example:
 ```SQL
-SELECT ST_GeomFromWKT('POINT(40.7128 -74.0060)') AS geometry
+SELECT ST_GeomFromGeoJSON(polygontable._c0) AS polygonshape
+FROM polygontable
 ```
 
 ## ST_GeomFromText
@@ -67,31 +66,18 @@ SELECT ST_GeomFromWKB(polygontable._c0) AS polygonshape
 FROM polygontable
 ```
 
-## ST_GeomFromGeoJSON
+## ST_GeomFromWKT
 
-Introduction: Construct a Geometry from GeoJson
+Introduction: Construct a Geometry from Wkt
 
-Format: `ST_GeomFromGeoJSON (GeoJson:string)`
-
-Since: `v1.2.0`
-
-SQL example:
-```SQL
-SELECT ST_GeomFromGeoJSON(polygontable._c0) AS polygonshape
-FROM polygontable
-```
-
-## ST_PointFromText
-
-Introduction: Construct a Point from Text, delimited by Delimiter
-
-Format: `ST_PointFromText (Text:string, Delimiter:char)`
+Format:
+`ST_GeomFromWKT (Wkt:string)`
 
 Since: `v1.2.0`
 
 SQL example:
 ```SQL
-SELECT ST_PointFromText('40.7128,-74.0060', ',') AS pointshape
+SELECT ST_GeomFromWKT('POINT(40.7128 -74.0060)') AS geometry
 ```
 
 ## ST_LineFromText
@@ -120,17 +106,31 @@ Spark SQL example:
 SELECT ST_LineStringFromText('Linestring(1 2, 3 4)') AS line
 ```
 
-## ST_PolygonFromText
+## ST_Point
 
-Introduction: Construct a Polygon from Text, delimited by Delimiter. Path must be closed
+Introduction: Construct a Point from X and Y
 
-Format: `ST_PolygonFromText (Text:string, Delimiter:char)`
+Format: `ST_Point (X:decimal, Y:decimal)`
+
+Since: `v1.2.1`
+
+SQL example:
+```SQL
+SELECT ST_Point(x, y) AS pointshape
+FROM pointtable
+```
+
+## ST_PointFromText
+
+Introduction: Construct a Point from Text, delimited by Delimiter
+
+Format: `ST_PointFromText (Text:string, Delimiter:char)`
 
 Since: `v1.2.0`
 
 SQL example:
 ```SQL
-SELECT ST_PolygonFromText('-74.0428197,40.6867969,-74.0421975,40.6921336,-74.0508020,40.6912794,-74.0428197,40.6867969', ',') AS polygonshape
+SELECT ST_PointFromText('40.7128,-74.0060', ',') AS pointshape
 ```
 
 ## ST_PolygonFromEnvelope
@@ -148,15 +148,15 @@ FROM pointdf
 WHERE ST_Contains(ST_PolygonFromEnvelope(1.0,100.0,1000.0,1100.0), pointdf.pointshape)
 ```
 
-## ST_GeomFromGeoHash
+## ST_PolygonFromText
 
-Introduction: Create Geometry from geohash string and optional precision
+Introduction: Construct a Polygon from Text, delimited by Delimiter. Path must be closed
 
-Format: `ST_GeomFromGeoHash(geohash: string, precision: int)`
+Format: `ST_PolygonFromText (Text:string, Delimiter:char)`
 
-Since: `v1.2.1`
+Since: `v1.2.0`
 
 SQL example:
 ```SQL
-SELECT ST_GeomFromGeoHash('s00twy01mt', 4) AS geom
+SELECT ST_PolygonFromText('-74.0428197,40.6867969,-74.0421975,40.6921336,-74.0508020,40.6912794,-74.0428197,40.6867969', ',') AS polygonshape
 ```

--- a/docs/api/flink/Function.md
+++ b/docs/api/flink/Function.md
@@ -1,47 +1,20 @@
-## ST_Distance
+## ST_AsEWKT
 
-Introduction: Return the Euclidean distance between A and B
+Introduction: Return the Extended Well-Known Text representation of a geometry.
+EWKT is an extended version of WKT which includes the SRID of the geometry.
+The format originated in PostGIS but is supported by many GIS tools.
+If the geometry is lacking SRID a WKT format is produced.
+[See ST_SetSRID](#ST_SetSRID)
 
-Format: `ST_Distance (A:geometry, B:geometry)`
+Format: `ST_AsEWKT (A:geometry)`
 
-Since: `v1.2.0`
+Since: `v1.2.1`
 
 Spark SQL example:
 ```SQL
-SELECT ST_Distance(polygondf.countyshape, polygondf.countyshape)
+SELECT ST_AsEWKT(polygondf.countyshape)
 FROM polygondf
 ```
-
-## ST_Transform
-
-Introduction:
-
-Transform the Spatial Reference System / Coordinate Reference System of A, from SourceCRS to TargetCRS
-
-!!!note
-	By default, this function uses lat/lon order. You can use ==ST_FlipCoordinates== to swap X and Y.
-
-!!!note
-	If ==ST_Transform== throws an Exception called "Bursa wolf parameters required", you need to disable the error notification in ST_Transform. You can append a boolean value at the end.
-
-Format: `ST_Transform (A:geometry, SourceCRS:string, TargetCRS:string ,[Optional] DisableError)`
-
-Since: `v1.2.0`
-
-Spark SQL example (simple):
-```SQL
-SELECT ST_Transform(polygondf.countyshape, 'epsg:4326','epsg:3857') 
-FROM polygondf
-```
-
-Spark SQL example (with optional parameters):
-```SQL
-SELECT ST_Transform(polygondf.countyshape, 'epsg:4326','epsg:3857', false)
-FROM polygondf
-```
-
-!!!note
-	The detailed EPSG information can be searched on [EPSG.io](https://epsg.io/).
 
 ## ST_Buffer
 
@@ -56,35 +29,59 @@ Spark SQL example:
 SELECT ST_Buffer(polygondf.countyshape, 1)
 FROM polygondf
 ```
-## ST_YMin
 
-Introduction: Return the minimum Y coordinate of A
+## ST_BuildArea
 
-Format: `ST_Y_Min (A:geometry)`
+Introduction: Returns the areal geometry formed by the constituent linework of the input geometry.
 
-Since: `v1.2.1`
-
-Spark SQL example:
-```SQL
-SELECT ST_YMin(ST_GeomFromText('POLYGON((0 0 1, 1 1 1, 1 2 1, 1 1 1, 0 0 1))'))
-```
-
-Output : 0
-
-## ST_YMax
-
-Introduction: Return the minimum Y coordinate of A
-
-Format: `ST_YMax (A:geometry)`
+Format: `ST_BuildArea (A:geometry)`
 
 Since: `v1.2.1`
 
-Spark SQL example:
+Example:
+
 ```SQL
-SELECT ST_YMax(ST_GeomFromText('POLYGON((0 0 1, 1 1 1, 1 2 1, 1 1 1, 0 0 1))'))
+SELECT ST_BuildArea(ST_Collect(smallDf, bigDf)) AS geom
+FROM smallDf, bigDf
 ```
 
-Output : 2
+Input: `MULTILINESTRING((0 0, 10 0, 10 10, 0 10, 0 0),(10 10, 20 10, 20 20, 10 20, 10 10))`
+
+Output: `MULTIPOLYGON(((0 0,0 10,10 10,10 0,0 0)),((10 10,10 20,20 20,20 10,10 10)))`
+
+## ST_Distance
+
+Introduction: Return the Euclidean distance between A and B
+
+Format: `ST_Distance (A:geometry, B:geometry)`
+
+Since: `v1.2.0`
+
+Spark SQL example:
+```SQL
+SELECT ST_Distance(polygondf.countyshape, polygondf.countyshape)
+FROM polygondf
+```
+
+## ST_ExteriorRing
+
+Introduction: Returns a LINESTRING representing the exterior ring (shell) of a POLYGON. Returns NULL if the geometry is not a polygon.
+
+Format: `ST_ExteriorRing(A:geometry)`
+
+Since: `v1.2.1`
+
+Examples:
+
+```SQL
+SELECT ST_ExteriorRing(df.geometry)
+FROM df
+```
+
+Input: `POLYGON ((0 0, 1 1, 2 1, 0 1, 1 -1, 0 0))`
+
+Output: `LINESTRING (0 0, 1 1, 2 1, 0 1, 1 -1, 0 0)`
+
 ## ST_FlipCoordinates
 
 Introduction: Returns a version of the given geometry with X and Y axis flipped.
@@ -102,6 +99,25 @@ FROM df
 Input: `POINT (1 2)`
 
 Output: `POINT (2 1)`
+
+## ST_Force_2D
+
+Introduction: Forces the geometries into a "2-dimensional mode" so that all output representations will only have the X and Y coordinates
+
+Format: `ST_Force_2D (A:geometry)`
+
+Since: `v1.2.1`
+
+Example:
+
+```SQL
+SELECT ST_Force_2D(df.geometry) AS geom
+FROM df
+```
+
+Input: `POLYGON((0 0 2,0 5 2,5 0 2,0 0 2),(1 1 2,3 1 2,1 3 2,1 1 2))`
+
+Output: `POLYGON((0 0,0 5,5 0,0 0),(1 1,3 1,1 3,1 1))`
 
 ## ST_GeoHash
 
@@ -144,57 +160,6 @@ SELECT ST_IsEmpty(polygondf.countyshape)
 FROM polygondf
 ```
 
-## ST_PointOnSurface
-
-Introduction: Returns a POINT guaranteed to lie on the surface.
-
-Format: `ST_PointOnSurface(A:geometry)`
-
-Since: `v1.2.1`
-
-Examples: 
-
-
-```SQL
-SELECT ST_PointOnSurface(df.geometry)
-FROM df
-```
-
-1.  Input: `POINT (0 5)`
-
-    Output: `POINT (0 5)`
-
-2.  Input: `LINESTRING(0 5, 0 10)`
-
-    Output: `POINT (0 5)`
-
-3.  Input: `POLYGON((0 0, 0 5, 5 5, 5 0, 0 0))`
-
-    Output: `POINT (2.5 2.5)`
-
-4.  Input: `LINESTRING(0 5 1, 0 0 1, 0 10 2)`
-
-    Output: `POINT Z(0 0 1)`  
-
-## ST_Reverse
-
-Introduction: Return the geometry with vertex order reversed
-
-Format: `ST_Reverse (A:geometry)`
-
-Since: `v1.2.1`
-
-Example:
-
-```SQL
-SELECT ST_Reverse(df.geometry) AS geom
-FROM df
-```
-
-Input: `POLYGON ((-0.5 -0.5, -0.5 0.5, 0.5 0.5, 0.5 -0.5, -0.5 -0.5))`
-
-Output: `POLYGON ((-0.5 -0.5, 0.5 -0.5, 0.5 0.5, -0.5 0.5, -0.5 -0.5))`
-
 ## ST_PointN
 
 Introduction: Return the Nth point in a single linestring or circular linestring in the geometry. Negative values are counted backwards from the end of the LineString, so that -1 is the last point. Returns NULL if there is no linestring in the geometry.
@@ -222,63 +187,86 @@ Input: `CIRCULARSTRING(1 1, 1 2, 2 4, 3 6, 1 2, 1 1), -1`
 
 Output: `POINT (1 1)`
 
+## ST_PointOnSurface
 
-## ST_ExteriorRing
+Introduction: Returns a POINT guaranteed to lie on the surface.
 
-Introduction: Returns a LINESTRING representing the exterior ring (shell) of a POLYGON. Returns NULL if the geometry is not a polygon.
-
-Format: `ST_ExteriorRing(A:geometry)`
+Format: `ST_PointOnSurface(A:geometry)`
 
 Since: `v1.2.1`
 
 Examples:
 
 ```SQL
-SELECT ST_ExteriorRing(df.geometry)
+SELECT ST_PointOnSurface(df.geometry)
 FROM df
 ```
 
-Input: `POLYGON ((0 0, 1 1, 2 1, 0 1, 1 -1, 0 0))`
+1.  Input: `POINT (0 5)`
 
-Output: `LINESTRING (0 0, 1 1, 2 1, 0 1, 1 -1, 0 0)`
+    Output: `POINT (0 5)`
 
+2.  Input: `LINESTRING(0 5, 0 10)`
 
-## ST_Force_2D
+    Output: `POINT (0 5)`
 
-Introduction: Forces the geometries into a "2-dimensional mode" so that all output representations will only have the X and Y coordinates
+3.  Input: `POLYGON((0 0, 0 5, 5 5, 5 0, 0 0))`
 
-Format: `ST_Force_2D (A:geometry)`
+    Output: `POINT (2.5 2.5)`
+
+4.  Input: `LINESTRING(0 5 1, 0 0 1, 0 10 2)`
+
+    Output: `POINT Z(0 0 1)`
+
+## ST_Reverse
+
+Introduction: Return the geometry with vertex order reversed
+
+Format: `ST_Reverse (A:geometry)`
 
 Since: `v1.2.1`
 
 Example:
 
 ```SQL
-SELECT ST_Force_2D(df.geometry) AS geom
+SELECT ST_Reverse(df.geometry) AS geom
 FROM df
 ```
 
-Input: `POLYGON((0 0 2,0 5 2,5 0 2,0 0 2),(1 1 2,3 1 2,1 3 2,1 1 2))`
+Input: `POLYGON ((-0.5 -0.5, -0.5 0.5, 0.5 0.5, 0.5 -0.5, -0.5 -0.5))`
 
-Output: `POLYGON((0 0,0 5,5 0,0 0),(1 1,3 1,1 3,1 1))`
+Output: `POLYGON ((-0.5 -0.5, 0.5 -0.5, 0.5 0.5, -0.5 0.5, -0.5 -0.5))`
 
-## ST_AsEWKT
+## ST_Transform
 
-Introduction: Return the Extended Well-Known Text representation of a geometry.
-EWKT is an extended version of WKT which includes the SRID of the geometry.
-The format originated in PostGIS but is supported by many GIS tools.
-If the geometry is lacking SRID a WKT format is produced.
-[See ST_SetSRID](#ST_SetSRID)
+Introduction:
 
-Format: `ST_AsEWKT (A:geometry)`
+Transform the Spatial Reference System / Coordinate Reference System of A, from SourceCRS to TargetCRS
 
-Since: `v1.2.1`
+!!!note
+By default, this function uses lat/lon order. You can use ==ST_FlipCoordinates== to swap X and Y.
 
-Spark SQL example:
+!!!note
+If ==ST_Transform== throws an Exception called "Bursa wolf parameters required", you need to disable the error notification in ST_Transform. You can append a boolean value at the end.
+
+Format: `ST_Transform (A:geometry, SourceCRS:string, TargetCRS:string ,[Optional] DisableError)`
+
+Since: `v1.2.0`
+
+Spark SQL example (simple):
 ```SQL
-SELECT ST_AsEWKT(polygondf.countyshape)
+SELECT ST_Transform(polygondf.countyshape, 'epsg:4326','epsg:3857') 
 FROM polygondf
 ```
+
+Spark SQL example (with optional parameters):
+```SQL
+SELECT ST_Transform(polygondf.countyshape, 'epsg:4326','epsg:3857', false)
+FROM polygondf
+```
+
+!!!note
+The detailed EPSG information can be searched on [EPSG.io](https://epsg.io/).
 
 ## ST_XMax
 
@@ -318,21 +306,32 @@ Input: `POLYGON ((-1 -11, 0 10, 1 11, 2 12, -1 -11))`
 
 Output: `-1`
 
-## ST_BuildArea
+## ST_YMax
 
-Introduction: Returns the areal geometry formed by the constituent linework of the input geometry.
+Introduction: Return the minimum Y coordinate of A
 
-Format: `ST_BuildArea (A:geometry)`
+Format: `ST_YMax (A:geometry)`
 
 Since: `v1.2.1`
 
-Example:
-
+Spark SQL example:
 ```SQL
-SELECT ST_BuildArea(ST_Collect(smallDf, bigDf)) AS geom
-FROM smallDf, bigDf
+SELECT ST_YMax(ST_GeomFromText('POLYGON((0 0 1, 1 1 1, 1 2 1, 1 1 1, 0 0 1))'))
 ```
 
-Input: `MULTILINESTRING((0 0, 10 0, 10 10, 0 10, 0 0),(10 10, 20 10, 20 20, 10 20, 10 10))`
+Output : 2
 
-Output: `MULTIPOLYGON(((0 0,0 10,10 10,10 0,0 0)),((10 10,10 20,20 20,20 10,10 10)))`
+## ST_YMin
+
+Introduction: Return the minimum Y coordinate of A
+
+Format: `ST_Y_Min (A:geometry)`
+
+Since: `v1.2.1`
+
+Spark SQL example:
+```SQL
+SELECT ST_YMin(ST_GeomFromText('POLYGON((0 0 1, 1 1 1, 1 2 1, 1 1 1, 0 0 1))'))
+```
+
+Output : 0

--- a/docs/api/flink/Predicate.md
+++ b/docs/api/flink/Predicate.md
@@ -13,21 +13,6 @@ FROM pointdf
 WHERE ST_Contains(ST_PolygonFromEnvelope(1.0,100.0,1000.0,1100.0), pointdf.arealandmark)
 ```
 
-## ST_Intersects
-
-Introduction: Return true if A intersects B
-
-Format: `ST_Intersects (A:geometry, B:geometry)`
-
-Since: `v1.2.0`
-
-SQL example:
-```SQL
-SELECT * 
-FROM pointdf 
-WHERE ST_Intersects(ST_PolygonFromEnvelope(1.0,100.0,1000.0,1100.0), pointdf.arealandmark)
-```
-
 ## ST_Disjoint
 
 Introduction: Return true if A and B are disjoint
@@ -41,6 +26,21 @@ Spark SQL example:
 SELECT *
 FROM pointdf 
 WHERE ST_Disjoinnt(ST_PolygonFromEnvelope(1.0,100.0,1000.0,1100.0), pointdf.arealandmark)
+```
+
+## ST_Intersects
+
+Introduction: Return true if A intersects B
+
+Format: `ST_Intersects (A:geometry, B:geometry)`
+
+Since: `v1.2.0`
+
+SQL example:
+```SQL
+SELECT * 
+FROM pointdf 
+WHERE ST_Intersects(ST_PolygonFromEnvelope(1.0,100.0,1000.0,1100.0), pointdf.arealandmark)
 ```
 
 ## ST_OrderingEquals

--- a/docs/api/sql/AggregateFunction.md
+++ b/docs/api/sql/AggregateFunction.md
@@ -12,20 +12,6 @@ SELECT ST_Envelope_Aggr(pointdf.arealandmark)
 FROM pointdf
 ```
 
-## ST_Union_Aggr
-
-Introduction: Return the polygon union of all polygons in A
-
-Format: `ST_Union_Aggr (A:geometryColumn)`
-
-Since: `v1.0.0`
-
-Spark SQL example:
-```SQL
-SELECT ST_Union_Aggr(polygondf.polygonshape)
-FROM polygondf
-```
-
 ## ST_Intersection_Aggr
 
 Introduction: Return the polygon intersection of all polygons in A
@@ -37,5 +23,19 @@ Since: `v1.0.0`
 Spark SQL example:
 ```SQL
 SELECT ST_Intersection_Aggr(polygondf.polygonshape)
+FROM polygondf
+```
+
+## ST_Union_Aggr
+
+Introduction: Return the polygon union of all polygons in A
+
+Format: `ST_Union_Aggr (A:geometryColumn)`
+
+Since: `v1.0.0`
+
+Spark SQL example:
+```SQL
+SELECT ST_Union_Aggr(polygondf.polygonshape)
 FROM polygondf
 ```

--- a/docs/api/sql/Constructor.md
+++ b/docs/api/sql/Constructor.md
@@ -1,36 +1,69 @@
-## ST_GeomFromWKT
-
-Introduction: Construct a Geometry from Wkt
-
-Format:
-`ST_GeomFromWKT (Wkt:string)`
+## Read ESRI Shapefile
+Introduction: Construct a DataFrame from a Shapefile
 
 Since: `v1.0.0`
 
-Spark SQL example:
-```SQL
-SELECT ST_GeomFromWKT(polygontable._c0) AS polygonshape
-FROM polygontable
+SparkSQL example:
+
+```Scala
+var spatialRDD = new SpatialRDD[Geometry]
+spatialRDD.rawSpatialRDD = ShapefileReader.readToGeometryRDD(sparkSession.sparkContext, shapefileInputLocation)
+var rawSpatialDf = Adapter.toDf(spatialRDD,sparkSession)
+rawSpatialDf.createOrReplaceTempView("rawSpatialDf")
+var spatialDf = sparkSession.sql("""
+          | ST_GeomFromWKT(rddshape), _c1, _c2
+          | FROM rawSpatialDf
+        """.stripMargin)
+spatialDf.show()
+spatialDf.printSchema()
 ```
 
-```SQL
-SELECT ST_GeomFromWKT('POINT(40.7128 -74.0060)') AS geometry
+!!!note
+The file extensions of .shp, .shx, .dbf must be in lowercase. Assume you have a shape file called ==myShapefile==, the file structure should be like this:
+```
+- shapefile1
+- shapefile2
+- myshapefile
+- myshapefile.shp
+- myshapefile.shx
+- myshapefile.dbf
+- myshapefile...
+- ...
 ```
 
-## ST_GeomFromWKB
+!!!warning
+Please make sure you use ==ST_GeomFromWKT== to create Geometry type column otherwise that column cannot be used in SedonaSQL.
 
-Introduction: Construct a Geometry from WKB string or Binary
+If the file you are reading contains non-ASCII characters you'll need to explicitly set the encoding
+via `sedona.global.charset` system property before the call to `ShapefileReader.readToGeometryRDD`.
 
-Format:
-`ST_GeomFromWKB (Wkb:string)`
-`ST_GeomFromWKB (Wkb:binary)`
+Example:
 
-Since: `v1.0.0`
+```Scala
+System.setProperty("sedona.global.charset", "utf8")
+```
+
+## ST_GeomFromGeoHash
+
+Introduction: Create Geometry from geohash string and optional precision
+
+Format: `ST_GeomFromGeoHash(geohash: string, precision: int)`
+
+Since: `v1.1.1`
 
 Spark SQL example:
 ```SQL
-SELECT ST_GeomFromWKB(polygontable._c0) AS polygonshape
-FROM polygontable
+SELECT ST_GeomFromGeoHash('s00twy01mt', 4) AS geom
+```
+
+result:
+
+```
++--------------------------------------------------------------------------------------------------------------------+
+|geom                                                                                                                |
++--------------------------------------------------------------------------------------------------------------------+
+|POLYGON ((0.703125 0.87890625, 0.703125 1.0546875, 1.0546875 1.0546875, 1.0546875 0.87890625, 0.703125 0.87890625)) |
++--------------------------------------------------------------------------------------------------------------------+
 ```
 
 ## ST_GeomFromGeoJSON
@@ -57,120 +90,39 @@ polygonDf.show()
 !!!warning
 	The way that SedonaSQL reads GeoJSON is different from that in SparkSQL
 
-## Read ESRI Shapefile
-Introduction: Construct a DataFrame from a Shapefile
+## ST_GeomFromWKB
 
-Since: `v1.0.0`
+Introduction: Construct a Geometry from WKB string or Binary
 
-SparkSQL example:
-
-```Scala
-var spatialRDD = new SpatialRDD[Geometry]
-spatialRDD.rawSpatialRDD = ShapefileReader.readToGeometryRDD(sparkSession.sparkContext, shapefileInputLocation)
-var rawSpatialDf = Adapter.toDf(spatialRDD,sparkSession)
-rawSpatialDf.createOrReplaceTempView("rawSpatialDf")
-var spatialDf = sparkSession.sql("""
-          | ST_GeomFromWKT(rddshape), _c1, _c2
-          | FROM rawSpatialDf
-        """.stripMargin)
-spatialDf.show()
-spatialDf.printSchema()
-```
-
-!!!note
-	The file extensions of .shp, .shx, .dbf must be in lowercase. Assume you have a shape file called ==myShapefile==, the file structure should be like this:
-	```
-	- shapefile1
-	- shapefile2
-	- myshapefile
-		- myshapefile.shp
-		- myshapefile.shx
-		- myshapefile.dbf
-		- myshapefile...
-		- ...
-	```
-
-!!!warning
-	Please make sure you use ==ST_GeomFromWKT== to create Geometry type column otherwise that column cannot be used in SedonaSQL.
-
-If the file you are reading contains non-ASCII characters you'll need to explicitly set the encoding
-via `sedona.global.charset` system property before the call to `ShapefileReader.readToGeometryRDD`.
-
-Example:
-
-```Scala
-System.setProperty("sedona.global.charset", "utf8")
-```
-
-
-## ST_Point
-
-Introduction: Construct a Point from X and Y
-
-Format: `ST_Point (X:decimal, Y:decimal)`
-Format: `ST_Point (X:decimal, Y:decimal, Z:decimal)`
+Format:
+`ST_GeomFromWKB (Wkb:string)`
+`ST_GeomFromWKB (Wkb:binary)`
 
 Since: `v1.0.0`
 
 Spark SQL example:
 ```SQL
-SELECT ST_Point(CAST(pointtable._c0 AS Decimal(24,20)), CAST(pointtable._c1 AS Decimal(24,20))) AS pointshape
-FROM pointtable
+SELECT ST_GeomFromWKB(polygontable._c0) AS polygonshape
+FROM polygontable
 ```
 
+## ST_GeomFromWKT
 
-## ST_PointFromText
+Introduction: Construct a Geometry from Wkt
 
-Introduction: Construct a Point from Text, delimited by Delimiter
-
-Format: `ST_PointFromText (Text:string, Delimiter:char)`
+Format:
+`ST_GeomFromWKT (Wkt:string)`
 
 Since: `v1.0.0`
 
 Spark SQL example:
 ```SQL
-SELECT ST_PointFromText(pointtable._c0,',') AS pointshape
-FROM pointtable
-```
-
-```SQL
-SELECT ST_PointFromText('40.7128,-74.0060', ',') AS pointshape
-```
-
-## ST_PolygonFromText
-
-Introduction: Construct a Polygon from Text, delimited by Delimiter. Path must be closed
-
-Format: `ST_PolygonFromText (Text:string, Delimiter:char)`
-
-Since: `v1.0.0`
-
-Spark SQL example:
-```SQL
-SELECT ST_PolygonFromText(polygontable._c0,',') AS polygonshape
+SELECT ST_GeomFromWKT(polygontable._c0) AS polygonshape
 FROM polygontable
 ```
 
 ```SQL
-SELECT ST_PolygonFromText('-74.0428197,40.6867969,-74.0421975,40.6921336,-74.0508020,40.6912794,-74.0428197,40.6867969', ',') AS polygonshape
-```
-
-## ST_LineStringFromText
-
-Introduction: Construct a LineString from Text, delimited by Delimiter
-
-Format: `ST_LineStringFromText (Text:string, Delimiter:char)`
-
-Since: `v1.0.0`
-
-Spark SQL example:
-```SQL
-SELECT ST_LineStringFromText(linestringtable._c0,',') AS linestringshape
-FROM linestringtable
-```
-
-```SQL
-SELECT ST_LineStringFromText('-74.0428197,40.6867969,-74.0421975,40.6921336,-74.0508020,40.6912794', ',') AS linestringshape
+SELECT ST_GeomFromWKT('POINT(40.7128 -74.0060)') AS geometry
 ```
 
 ## ST_LineFromText
@@ -192,6 +144,57 @@ FROM linetable
 SELECT ST_LineFromText('Linestring(1 2, 3 4)') AS line
 ```
 
+## ST_LineStringFromText
+
+Introduction: Construct a LineString from Text, delimited by Delimiter
+
+Format: `ST_LineStringFromText (Text:string, Delimiter:char)`
+
+Since: `v1.0.0`
+
+Spark SQL example:
+```SQL
+SELECT ST_LineStringFromText(linestringtable._c0,',') AS linestringshape
+FROM linestringtable
+```
+
+```SQL
+SELECT ST_LineStringFromText('-74.0428197,40.6867969,-74.0421975,40.6921336,-74.0508020,40.6912794', ',') AS linestringshape
+```
+
+## ST_Point
+
+Introduction: Construct a Point from X and Y
+
+Format: `ST_Point (X:decimal, Y:decimal)`
+Format: `ST_Point (X:decimal, Y:decimal, Z:decimal)`
+
+Since: `v1.0.0`
+
+Spark SQL example:
+```SQL
+SELECT ST_Point(CAST(pointtable._c0 AS Decimal(24,20)), CAST(pointtable._c1 AS Decimal(24,20))) AS pointshape
+FROM pointtable
+```
+
+## ST_PointFromText
+
+Introduction: Construct a Point from Text, delimited by Delimiter
+
+Format: `ST_PointFromText (Text:string, Delimiter:char)`
+
+Since: `v1.0.0`
+
+Spark SQL example:
+```SQL
+SELECT ST_PointFromText(pointtable._c0,',') AS pointshape
+FROM pointtable
+```
+
+```SQL
+SELECT ST_PointFromText('40.7128,-74.0060', ',') AS pointshape
+```
+
 ## ST_PolygonFromEnvelope
 
 Introduction: Construct a Polygon from MinX, MinY, MaxX, MaxY.
@@ -207,25 +210,20 @@ FROM pointdf
 WHERE ST_Contains(ST_PolygonFromEnvelope(1.0,100.0,1000.0,1100.0), pointdf.pointshape)
 ```
 
-## ST_GeomFromGeoHash
+## ST_PolygonFromText
 
-Introduction: Create Geometry from geohash string and optional precision
+Introduction: Construct a Polygon from Text, delimited by Delimiter. Path must be closed
 
-Format: `ST_GeomFromGeoHash(geohash: string, precision: int)`
+Format: `ST_PolygonFromText (Text:string, Delimiter:char)`
 
-Since: `v1.1.1`
+Since: `v1.0.0`
 
 Spark SQL example:
 ```SQL
-SELECT ST_GeomFromGeoHash('s00twy01mt', 4) AS geom
+SELECT ST_PolygonFromText(polygontable._c0,',') AS polygonshape
+FROM polygontable
 ```
 
-result:
-
-```
-+--------------------------------------------------------------------------------------------------------------------+
-|geom                                                                                                                |
-+--------------------------------------------------------------------------------------------------------------------+
-|POLYGON ((0.703125 0.87890625, 0.703125 1.0546875, 1.0546875 1.0546875, 1.0546875 0.87890625, 0.703125 0.87890625)) |
-+--------------------------------------------------------------------------------------------------------------------+
+```SQL
+SELECT ST_PolygonFromText('-74.0428197,40.6867969,-74.0421975,40.6921336,-74.0508020,40.6912794,-74.0428197,40.6867969', ',') AS polygonshape
 ```

--- a/docs/api/sql/Function.md
+++ b/docs/api/sql/Function.md
@@ -1,48 +1,3 @@
-## ST_Distance
-
-Introduction: Return the Euclidean distance between A and B
-
-Format: `ST_Distance (A:geometry, B:geometry)`
-
-Since: `v1.0.0`
-
-Spark SQL example:
-```SQL
-SELECT ST_Distance(polygondf.countyshape, polygondf.countyshape)
-FROM polygondf
-```
-
-## ST_YMin
-
-Introduction: Return the minimum Y coordinate of A
-
-Format: `ST_Y_Min (A:geometry)`
-
-Since: `v1.2.1`
-
-Spark SQL example:
-```SQL
-SELECT ST_YMin(ST_GeomFromText('POLYGON((0 0 1, 1 1 1, 1 2 1, 1 1 1, 0 0 1))'))
-```
-
-Output : 0
-
-## ST_YMax
-
-Introduction: Return the minimum Y coordinate of A
-
-Format: `ST_YMax (A:geometry)`
-
-Since: `v1.2.1`
-
-Spark SQL example:
-```SQL
-SELECT ST_YMax(ST_GeomFromText('POLYGON((0 0 1, 1 1 1, 1 2 1, 1 1 1, 0 0 1))'))
-```
-
-Output: 2
-
-
 ## ST_3DDistance
 
 Introduction: Return the 3-dimensional minimum cartesian distance between A and B
@@ -57,47 +12,27 @@ SELECT ST_3DDistance(polygondf.countyshape, polygondf.countyshape)
 FROM polygondf
 ```
 
-## ST_ConvexHull
+## ST_AddPoint
 
-Introduction: Return the Convex Hull of polgyon A
+Introduction: RETURN Linestring with additional point at the given index, if position is not available the point will be added at the end of line.
 
-Format: `ST_ConvexHull (A:geometry)`
+Format: `ST_AddPoint(geom: geometry, point: geometry, position: integer)`
+
+Format: `ST_AddPoint(geom: geometry, point: geometry)`
 
 Since: `v1.0.0`
 
 Spark SQL example:
 ```SQL
-SELECT ST_ConvexHull(polygondf.countyshape)
-FROM polygondf
+SELECT ST_AddPoint(ST_GeomFromText("LINESTRING(0 0, 1 1, 1 0)"), ST_GeomFromText("Point(21 52)"), 1)
+
+SELECT ST_AddPoint(ST_GeomFromText("Linestring(0 0, 1 1, 1 0)"), ST_GeomFromText("Point(21 52)"))
 ```
 
-## ST_Envelope
-
-Introduction: Return the envelop boundary of A
-
-Format: `ST_Envelope (A:geometry)`
-
-Since: `v1.0.0`
-
-Spark SQL example:
-
-```SQL
-SELECT ST_Envelope(polygondf.countyshape)
-FROM polygondf
+Output:
 ```
-
-## ST_Length
-
-Introduction: Return the perimeter of A
-
-Format: ST_Length (A:geometry)
-
-Since: `v1.0.0`
-
-Spark SQL example:
-```SQL
-SELECT ST_Length(polygondf.countyshape)
-FROM polygondf
+LINESTRING(0 0, 21 52, 1 1, 1 0)
+LINESTRING(0 0, 1 1, 1 0, 21 52)
 ```
 
 ## ST_Area
@@ -111,208 +46,6 @@ Since: `v1.0.0`
 Spark SQL example:
 ```SQL
 SELECT ST_Area(polygondf.countyshape)
-FROM polygondf
-```
-
-## ST_Centroid
-
-Introduction: Return the centroid point of A
-
-Format: `ST_Centroid (A:geometry)`
-
-Since: `v1.0.0`
-
-Spark SQL example:
-```SQL
-SELECT ST_Centroid(polygondf.countyshape)
-FROM polygondf
-```
-
-
-
-## ST_Transform
-
-Introduction:
-
-Transform the Spatial Reference System / Coordinate Reference System of A, from SourceCRS to TargetCRS
-
-!!!note
-	By default, this function uses lat/lon order. You can use ==ST_FlipCoordinates== to swap X and Y.
-
-!!!note
-	If ==ST_Transform== throws an Exception called "Bursa wolf parameters required", you need to disable the error notification in ST_Transform. You can append a boolean value at the end.
-
-Format: `ST_Transform (A:geometry, SourceCRS:string, TargetCRS:string ,[Optional] DisableError)`
-
-Since: `v1.0.0`
-
-Spark SQL example (simple):
-```SQL
-SELECT ST_Transform(polygondf.countyshape, 'epsg:4326','epsg:3857') 
-FROM polygondf
-```
-
-Spark SQL example (with optional parameters):
-```SQL
-SELECT ST_Transform(polygondf.countyshape, 'epsg:4326','epsg:3857', false)
-FROM polygondf
-```
-
-!!!note
-	The detailed EPSG information can be searched on [EPSG.io](https://epsg.io/).
-
-## ST_Intersection
-
-Introduction: Return the intersection geometry of A and B
-
-Format: `ST_Intersection (A:geometry, B:geometry)`
-
-Since: `v1.0.0`
-
-Spark SQL example:
-
-```SQL
-SELECT ST_Intersection(polygondf.countyshape, polygondf.countyshape)
-FROM polygondf
-```
-
-## ST_IsValid
-
-Introduction: Test if a geometry is well formed
-
-Format: `ST_IsValid (A:geometry)`
-
-Since: `v1.0.0`
-
-Spark SQL example:
-
-```SQL
-SELECT ST_IsValid(polygondf.countyshape)
-FROM polygondf
-```
-
-## ST_IsEmpty
-
-Introduction: Test if a geometry is empty geometry
-
-Format: `ST_IsEmpty (A:geometry)`
-
-Since: `v1.2.1`
-
-Spark SQL example:
-
-```SQL
-SELECT ST_IsEmpty(polygondf.countyshape)
-FROM polygondf
-```
-
-## ST_MakeValid
-
-Introduction: Given an invalid geometry, create a valid representation of the geometry.
-
-Collapsed geometries are either converted to empty (keepCollaped=true) or a valid geometry of lower dimension (keepCollapsed=false).
-Default is keepCollapsed=false.
-
-Format: `ST_MakeValid (A:geometry)`
-
-Format: `ST_MakeValid (A:geometry, keepCollapsed:Boolean)`
-
-Since: `v1.0.0`
-
-Spark SQL example:
-
-```SQL
-WITH linestring AS (
-    SELECT ST_GeomFromWKT('LINESTRING(1 1, 1 1)') AS geom
-) SELECT ST_MakeValid(geom), ST_MakeValid(geom, true) FROM linestring
-```
-
-Result:
-```
-+------------------+------------------------+
-|st_makevalid(geom)|st_makevalid(geom, true)|
-+------------------+------------------------+
-|  LINESTRING EMPTY|             POINT (1 1)|
-+------------------+------------------------+
-```
-
-!!!note
-    In Sedona up to and including version 1.2 the behaviour of ST_MakeValid was different.
-    Be sure to check you code when upgrading. 
-    The previous implementation only worked for (multi)polygons and had a different interpretation of the second, boolean, argument.
-    It would also sometimes return multiple geometries for a single geomtry input.
-
-
-## ST_PrecisionReduce
-
-Introduction: Reduce the decimals places in the coordinates of the geometry to the given number of decimal places. The last decimal place will be rounded.
-
-Format: `ST_PrecisionReduce (A:geometry, B:int)`
-
-Since: `v1.0.0`
-
-Spark SQL example:
-
-```SQL
-SELECT ST_PrecisionReduce(polygondf.countyshape, 9)
-FROM polygondf
-```
-The new coordinates will only have 9 decimal places.
-
-## ST_IsSimple
-
-Introduction: Test if geometry's only self-intersections are at boundary points.
-
-Format: `ST_IsSimple (A:geometry)`
-
-Since: `v1.0.0`
-
-Spark SQL example:
-
-```SQL
-SELECT ST_IsSimple(polygondf.countyshape)
-FROM polygondf
-```
-
-## ST_Buffer
-
-Introduction: Returns a geometry/geography that represents all points whose distance from this Geometry/geography is less than or equal to distance.
-
-Format: `ST_Buffer (A:geometry, buffer: Double)`
-
-Since: `v1.0.0`
-
-Spark SQL example:
-```SQL
-SELECT ST_Buffer(polygondf.countyshape, 1)
-FROM polygondf
-```
-
-## ST_AsText
-
-Introduction: Return the Well-Known Text string representation of a geometry
-
-Format: `ST_AsText (A:geometry)`
-
-Since: `v1.0.0`
-
-Spark SQL example:
-```SQL
-SELECT ST_AsText(polygondf.countyshape)
-FROM polygondf
-```
-
-## ST_AsGeoJSON
-
-Introduction: Return the [GeoJSON](https://geojson.org/) string representation of a geometry
-
-Format: `ST_AsGeoJSON (A:geometry)`
-
-Since: `v1.0.0`
-
-Spark SQL example:
-```SQL
-SELECT ST_AsGeoJSON(polygondf.countyshape)
 FROM polygondf
 ```
 
@@ -366,89 +99,32 @@ SELECT ST_AsEWKT(polygondf.countyshape)
 FROM polygondf
 ```
 
-## ST_SRID
+## ST_AsGeoJSON
 
-Introduction: Return the spatial refence system identifier (SRID) of the geometry.
+Introduction: Return the [GeoJSON](https://geojson.org/) string representation of a geometry
 
-Format: `ST_SRID (A:geometry)`
-
-Since: `v1.1.1`
-
-Spark SQL example:
-```SQL
-SELECT ST_SRID(polygondf.countyshape)
-FROM polygondf
-```
-
-## ST_SetSRID
-
-Introduction: Sets the spatial refence system identifier (SRID) of the geometry.
-
-Format: `ST_SetSRID (A:geometry, srid: Integer)`
-
-Since: `v1.1.1`
-
-Spark SQL example:
-```SQL
-SELECT ST_SetSRID(polygondf.countyshape, 3021)
-FROM polygondf
-```
-
-## ST_NPoints
-
-Introduction: Return points of the geometry
-
-Since: `v1.0.0`
-
-Format: `ST_NPoints (A:geometry)`
-
-```SQL
-SELECT ST_NPoints(polygondf.countyshape)
-FROM polygondf
-```
-
-## ST_SimplifyPreserveTopology
-
-Introduction: Simplifies a geometry and ensures that the result is a valid geometry having the same dimension and number of components as the input,
-              and with the components having the same topological relationship.
-
-Since: `v1.0.0`
-
-Format: `ST_SimplifyPreserveTopology (A:geometry, distanceTolerance: Double)`
-
-```SQL
-SELECT ST_SimplifyPreserveTopology(polygondf.countyshape, 10.0)
-FROM polygondf
-```
-
-## ST_GeometryType
-
-Introduction: Returns the type of the geometry as a string. EG: 'ST_Linestring', 'ST_Polygon' etc.
-
-Format: `ST_GeometryType (A:geometry)`
+Format: `ST_AsGeoJSON (A:geometry)`
 
 Since: `v1.0.0`
 
 Spark SQL example:
 ```SQL
-SELECT ST_GeometryType(polygondf.countyshape)
+SELECT ST_AsGeoJSON(polygondf.countyshape)
 FROM polygondf
 ```
 
-## ST_LineMerge
+## ST_AsText
 
-Introduction: Returns a LineString formed by sewing together the constituent line work of a MULTILINESTRING.
+Introduction: Return the Well-Known Text string representation of a geometry
 
-!!!note
-    Only works for MULTILINESTRING. Using other geometry will return a GEOMETRYCOLLECTION EMPTY. If the MultiLineString can't be merged, the original MULTILINESTRING is returned.
-
-Format: `ST_LineMerge (A:geometry)`
+Format: `ST_AsText (A:geometry)`
 
 Since: `v1.0.0`
 
+Spark SQL example:
 ```SQL
-SELECT ST_LineMerge(geometry)
-FROM df
+SELECT ST_AsText(polygondf.countyshape)
+FROM polygondf
 ```
 
 ## ST_Azimuth
@@ -466,65 +142,246 @@ SELECT ST_Azimuth(ST_POINT(0.0 25.0), ST_POINT(0.0 0.0))
 
 Output: `3.141592653589793`
 
-## ST_X
+## ST_Boundary
 
-Introduction: Returns X Coordinate of given Point null otherwise.
+Introduction: Returns the closure of the combinatorial boundary of this Geometry.
 
-Format: `ST_X(pointA: Point)`
-
-Since: `v1.0.0`
-
-Spark SQL example:
-```SQL
-SELECT ST_X(ST_POINT(0.0 25.0))
-```
-
-Output: `0.0`
-
-## ST_Y
-
-Introduction: Returns Y Coordinate of given Point, null otherwise.
-
-Format: `ST_Y(pointA: Point)`
+Format: `ST_Boundary(geom: geometry)`
 
 Since: `v1.0.0`
 
 Spark SQL example:
 ```SQL
-SELECT ST_Y(ST_POINT(0.0 25.0))
+SELECT ST_Boundary(ST_GeomFromText('POLYGON((1 1,0 0, -1 1, 1 1))'))
 ```
 
-Output: `25.0`
+Output: `LINESTRING (1 1, 0 0, -1 1, 1 1)`
 
-## ST_Z
+## ST_Buffer
 
-Introduction: Returns Z Coordinate of given Point, null otherwise.
+Introduction: Returns a geometry/geography that represents all points whose distance from this Geometry/geography is less than or equal to distance.
 
-Format: `ST_Z(pointA: Point)`
+Format: `ST_Buffer (A:geometry, buffer: Double)`
+
+Since: `v1.0.0`
+
+Spark SQL example:
+```SQL
+SELECT ST_Buffer(polygondf.countyshape, 1)
+FROM polygondf
+```
+
+## ST_BuildArea
+
+Introduction: Returns the areal geometry formed by the constituent linework of the input geometry.
+
+Format: `ST_BuildArea (A:geometry)`
+
+Since: `v1.2.1`
+
+Example:
+
+```SQL
+SELECT ST_BuildArea(
+    ST_GeomFromText('MULTILINESTRING((0 0, 20 0, 20 20, 0 20, 0 0),(2 2, 18 2, 18 18, 2 18, 2 2))')
+) AS geom
+```
+
+Result:
+
+```
+
++----------------------------------------------------------------------------+
+|geom                                                                        |
++----------------------------------------------------------------------------+
+|POLYGON((0 0,0 20,20 20,20 0,0 0),(2 2,18 2,18 18,2 18,2 2))                |
++----------------------------------------------------------------------------+
+```
+
+## ST_Centroid
+
+Introduction: Return the centroid point of A
+
+Format: `ST_Centroid (A:geometry)`
+
+Since: `v1.0.0`
+
+Spark SQL example:
+```SQL
+SELECT ST_Centroid(polygondf.countyshape)
+FROM polygondf
+```
+
+## ST_Collect
+
+Introduction: Returns MultiGeometry object based on geometry column/s or array with geometries
+
+Format
+
+`ST_Collect(*geom: geometry)`
+
+`ST_Collect(geom: array<geometry>)`
 
 Since: `v1.2.0`
 
-Spark SQL example:
+Example:
+
 ```SQL
-SELECT ST_Z(ST_POINT(0.0 25.0 11.0))
+SELECT ST_Collect(
+    ST_GeomFromText('POINT(21.427834 52.042576573)'),
+    ST_GeomFromText('POINT(45.342524 56.342354355)')
+) AS geom
 ```
 
-Output: `11.0`
+Result:
 
-## ST_StartPoint
+```
++---------------------------------------------------------------+
+|geom                                                           |
++---------------------------------------------------------------+
+|MULTIPOINT ((21.427834 52.042576573), (45.342524 56.342354355))|
++---------------------------------------------------------------+
+```
 
-Introduction: Returns first point of given linestring.
+Example:
 
-Format: `ST_StartPoint(geom: geometry)`
+```SQL
+SELECT ST_Collect(
+    Array(
+        ST_GeomFromText('POINT(21.427834 52.042576573)'),
+        ST_GeomFromText('POINT(45.342524 56.342354355)')
+    )
+) AS geom
+```
+
+Result:
+
+```
++---------------------------------------------------------------+
+|geom                                                           |
++---------------------------------------------------------------+
+|MULTIPOINT ((21.427834 52.042576573), (45.342524 56.342354355))|
++---------------------------------------------------------------+
+```
+
+## ST_CollectionExtract
+
+Introduction: Returns a homogeneous multi-geometry from a given geometry collection.
+
+The type numbers are:
+1. POINT
+2. LINESTRING
+3. POLYGON
+
+If the type parameter is omitted a multi-geometry of the highest dimension is returned.
+
+Format: `ST_CollectionExtract (A:geometry)`
+
+Format: `ST_CollectionExtract (A:geometry, type:Int)`
+
+Since: `v1.2.1`
+
+Example:
+
+```SQL
+WITH test_data as (
+    ST_GeomFromText(
+        'GEOMETRYCOLLECTION(POINT(40 10), POLYGON((0 0, 0 5, 5 5, 5 0, 0 0)))'
+    ) as geom
+)
+SELECT ST_CollectionExtract(geom) as c1, ST_CollectionExtract(geom, 1) as c2 
+FROM test_data
+
+```
+
+Result:
+
+```
++----------------------------------------------------------------------------+
+|c1                                        |c2                               |
++----------------------------------------------------------------------------+
+|MULTIPOLYGON(((0 0, 0 5, 5 5, 5 0, 0 0))) |MULTIPOINT(40 10)                |              |
++----------------------------------------------------------------------------+
+```
+
+## ST_ConvexHull
+
+Introduction: Return the Convex Hull of polgyon A
+
+Format: `ST_ConvexHull (A:geometry)`
 
 Since: `v1.0.0`
 
 Spark SQL example:
 ```SQL
-SELECT ST_StartPoint(ST_GeomFromText('LINESTRING(100 150,50 60, 70 80, 160 170)'))
+SELECT ST_ConvexHull(polygondf.countyshape)
+FROM polygondf
 ```
 
-Output: `POINT(100 150)`
+## ST_Difference
+
+Introduction: Return the difference between geometry A and B (return part of geometry A that does not intersect geometry B)
+
+Format: `ST_Difference (A:geometry, B:geometry)`
+
+Since: `v1.2.0`
+
+Example:
+
+```SQL
+SELECT ST_Difference(ST_GeomFromWKT('POLYGON ((-3 -3, 3 -3, 3 3, -3 3, -3 -3))'), ST_GeomFromWKT('POLYGON ((0 -4, 4 -4, 4 4, 0 4, 0 -4))'))
+```
+
+Result:
+
+```
+POLYGON ((0 -3, -3 -3, -3 3, 0 3, 0 -3))
+```
+
+## ST_Distance
+
+Introduction: Return the Euclidean distance between A and B
+
+Format: `ST_Distance (A:geometry, B:geometry)`
+
+Since: `v1.0.0`
+
+Spark SQL example:
+```SQL
+SELECT ST_Distance(polygondf.countyshape, polygondf.countyshape)
+FROM polygondf
+```
+
+## ST_Dump
+
+Introduction: It expands the geometries. If the geometry is simple (Point, Polygon Linestring etc.) it returns the geometry
+itself, if the geometry is collection or multi it returns record for each of collection components.
+
+Format: `ST_Dump(geom: geometry)`
+
+Since: `v1.0.0`
+
+Spark SQL example:
+```SQL
+SELECT ST_Dump(ST_GeomFromText('MULTIPOINT ((10 40), (40 30), (20 20), (30 10))'))
+```
+
+Output: `[POINT (10 40), POINT (40 30), POINT (20 20), POINT (30 10)]`
+
+## ST_DumpPoints
+
+Introduction: Returns list of Points which geometry consists of.
+
+Format: `ST_DumpPoints(geom: geometry)`
+
+Since: `v1.0.0`
+
+Spark SQL example:
+```SQL
+SELECT ST_DumpPoints(ST_GeomFromText('LINESTRING (0 0, 1 1, 1 0)')) 
+```
+
+Output: `[POINT (0 0), POINT (0 1), POINT (1 1), POINT (1 0), POINT (0 0)]`
 
 ## ST_EndPoint
 
@@ -541,20 +398,20 @@ SELECT ST_EndPoint(ST_GeomFromText('LINESTRING(100 150,50 60, 70 80, 160 170)'))
 
 Output: `POINT(160 170)`
 
-## ST_Boundary
+## ST_Envelope
 
-Introduction: Returns the closure of the combinatorial boundary of this Geometry.
+Introduction: Return the envelop boundary of A
 
-Format: `ST_Boundary(geom: geometry)`
+Format: `ST_Envelope (A:geometry)`
 
 Since: `v1.0.0`
 
 Spark SQL example:
-```SQL
-SELECT ST_Boundary(ST_GeomFromText('POLYGON((1 1,0 0, -1 1, 1 1))'))
-```
 
-Output: `LINESTRING (1 1, 0 0, -1 1, 1 1)`
+```SQL
+SELECT ST_Envelope(polygondf.countyshape)
+FROM polygondf
+```
 
 ## ST_ExteriorRing
 
@@ -570,168 +427,6 @@ SELECT ST_ExteriorRing(ST_GeomFromText('POLYGON((0 0 1, 1 1 1, 1 2 1, 1 1 1, 0 0
 ```
 
 Output: `LINESTRING (0 0, 1 1, 1 2, 1 1, 0 0)`
-
-## ST_GeometryN
-
-Introduction: Return the 1-based Nth geometry if the geometry is a GEOMETRYCOLLECTION, (MULTI)POINT, (MULTI)LINESTRING, MULTICURVE or (MULTI)POLYGON Otherwise, return null
-
-Format: `ST_GeometryN(geom: geometry, n: Int)`
-
-Since: `v1.0.0`
-
-Spark SQL example:
-```SQL
-SELECT ST_GeometryN(ST_GeomFromText('MULTIPOINT((1 2), (3 4), (5 6), (8 9))'), 1)
-```
-
-Output: `POINT (3 4)`
-
-## ST_InteriorRingN
-
-Introduction: Returns the Nth interior linestring ring of the polygon geometry. Returns NULL if the geometry is not a polygon or the given N is out of range
-
-Format: `ST_InteriorRingN(geom: geometry, n: Int)`
-
-Since: `v1.0.0`
-
-Spark SQL example:
-```SQL
-SELECT ST_InteriorRingN(ST_GeomFromText('POLYGON((0 0, 0 5, 5 5, 5 0, 0 0), (1 1, 2 1, 2 2, 1 2, 1 1), (1 3, 2 3, 2 4, 1 4, 1 3), (3 3, 4 3, 4 4, 3 4, 3 3))'), 0)
-```
-
-Output: `LINESTRING (1 1, 2 1, 2 2, 1 2, 1 1)`
-
-## ST_Dump
-
-Introduction: It expands the geometries. If the geometry is simple (Point, Polygon Linestring etc.) it returns the geometry
-itself, if the geometry is collection or multi it returns record for each of collection components.
- 
-Format: `ST_Dump(geom: geometry)`
-
-Since: `v1.0.0`
-
-Spark SQL example:
-```SQL
-SELECT ST_Dump(ST_GeomFromText('MULTIPOINT ((10 40), (40 30), (20 20), (30 10))'))
-```
-
-Output: `[POINT (10 40), POINT (40 30), POINT (20 20), POINT (30 10)]`
-
-## ST_DumpPoints
-
-Introduction: Returns list of Points which geometry consists of.
- 
-Format: `ST_DumpPoints(geom: geometry)`
-
-Since: `v1.0.0`
-
-Spark SQL example:
-```SQL
-SELECT ST_DumpPoints(ST_GeomFromText('LINESTRING (0 0, 1 1, 1 0)')) 
-```
-
-Output: `[POINT (0 0), POINT (0 1), POINT (1 1), POINT (1 0), POINT (0 0)]`
-
-
-## ST_IsClosed
-
-Introduction: RETURNS true if the LINESTRING start and end point are the same.
- 
-Format: `ST_IsClosed(geom: geometry)`
-
-Since: `v1.0.0`
-
-Spark SQL example:
-```SQL
-SELECT ST_IsClosed(ST_GeomFromText('LINESTRING(0 0, 1 1, 1 0)'))
-```
-
-Output: `false`
-
-## ST_NumInteriorRings
-
-Introduction: RETURNS number of interior rings of polygon geometries.
- 
-Format: `ST_NumInteriorRings(geom: geometry)`
-
-Since: `v1.0.0`
-
-Spark SQL example:
-```SQL
-SELECT ST_NumInteriorRings(ST_GeomFromText('POLYGON ((0 0, 0 5, 5 5, 5 0, 0 0), (1 1, 2 1, 2 2, 1 2, 1 1))'))
-```
-
-Output: `1`
-
-## ST_AddPoint
-
-Introduction: RETURN Linestring with additional point at the given index, if position is not available the point will be added at the end of line.
- 
-Format: `ST_AddPoint(geom: geometry, point: geometry, position: integer)`
-
-Format: `ST_AddPoint(geom: geometry, point: geometry)`
-
-Since: `v1.0.0`
-
-Spark SQL example:
-```SQL
-SELECT ST_AddPoint(ST_GeomFromText("LINESTRING(0 0, 1 1, 1 0)"), ST_GeomFromText("Point(21 52)"), 1)
-
-SELECT ST_AddPoint(ST_GeomFromText("Linestring(0 0, 1 1, 1 0)"), ST_GeomFromText("Point(21 52)"))
-```
-
-Output:
-```
-LINESTRING(0 0, 21 52, 1 1, 1 0)
-LINESTRING(0 0, 1 1, 1 0, 21 52)
-```
-
-
-## ST_RemovePoint
-
-Introduction: RETURN Line with removed point at given index, position can be omitted and then last one will be removed.
- 
-Format: `ST_RemovePoint(geom: geometry, position: integer)`
-
-Format: `ST_RemovePoint(geom: geometry)`
-
-Since: `v1.0.0`
-
-Spark SQL example:
-```SQL
-SELECT ST_RemovePoint(ST_GeomFromText("LINESTRING(0 0, 1 1, 1 0)"), 1)
-```
-
-Output: `LINESTRING(0 0, 1 0)`
-
-## ST_IsRing
-
-Introduction: RETURN true if LINESTRING is ST_IsClosed and ST_IsSimple.
- 
-Format: `ST_IsRing(geom: geometry)`
-
-Since: `v1.0.0`
-
-Spark SQL example:
-```SQL
-SELECT ST_IsRing(ST_GeomFromText("LINESTRING(0 0, 0 1, 1 1, 1 0, 0 0)"))
-```
-
-Output: `true`
-
-## ST_NumGeometries
-
-Introduction: Returns the number of Geometries. If geometry is a GEOMETRYCOLLECTION (or MULTI*) return the number of geometries, for single geometries will return 1.
-
-Format: `ST_NumGeometries (A:geometry)`
-
-Since: `v1.0.0`
-
-```SQL
-SELECT ST_NumGeometries(df.geometry)
-FROM df
-```
-
 
 ## ST_FlipCoordinates
 
@@ -751,6 +446,300 @@ Input: `POINT (1 2)`
 
 Output: `POINT (2 1)`
 
+## ST_Force_2D
+
+Introduction: Forces the geometries into a "2-dimensional mode" so that all output representations will only have the X and Y coordinates
+
+Format: `ST_Force_2D (A:geometry)`
+
+Since: `v1.2.1`
+
+Example:
+
+```SQL
+SELECT ST_AsText(
+    ST_Force_2D(ST_GeomFromText('POLYGON((0 0 2,0 5 2,5 0 2,0 0 2),(1 1 2,3 1 2,1 3 2,1 1 2))'))
+) AS geom
+```
+
+Result:
+
+```
++---------------------------------------------------------------+
+|geom                                                           |
++---------------------------------------------------------------+
+|POLYGON((0 0,0 5,5 0,0 0),(1 1,3 1,1 3,1 1))                   |
++---------------------------------------------------------------+
+```
+
+## ST_GeoHash
+
+Introduction: Returns GeoHash of the geometry with given precision
+
+Format: `ST_GeoHash(geom: geometry, precision: int)`
+
+Since: `v1.1.1`
+
+Example:
+
+Query:
+
+```SQL
+SELECT ST_GeoHash(ST_GeomFromText('POINT(21.427834 52.042576573)'), 5) AS geohash
+```
+
+Result:
+
+```
++-----------------------------+
+|geohash                      |
++-----------------------------+
+|u3r0p                        |
++-----------------------------+
+```
+
+## ST_GeometryN
+
+Introduction: Return the 1-based Nth geometry if the geometry is a GEOMETRYCOLLECTION, (MULTI)POINT, (MULTI)LINESTRING, MULTICURVE or (MULTI)POLYGON Otherwise, return null
+
+Format: `ST_GeometryN(geom: geometry, n: Int)`
+
+Since: `v1.0.0`
+
+Spark SQL example:
+```SQL
+SELECT ST_GeometryN(ST_GeomFromText('MULTIPOINT((1 2), (3 4), (5 6), (8 9))'), 1)
+```
+
+Output: `POINT (3 4)`
+
+## ST_GeometryType
+
+Introduction: Returns the type of the geometry as a string. EG: 'ST_Linestring', 'ST_Polygon' etc.
+
+Format: `ST_GeometryType (A:geometry)`
+
+Since: `v1.0.0`
+
+Spark SQL example:
+```SQL
+SELECT ST_GeometryType(polygondf.countyshape)
+FROM polygondf
+```
+
+## ST_InteriorRingN
+
+Introduction: Returns the Nth interior linestring ring of the polygon geometry. Returns NULL if the geometry is not a polygon or the given N is out of range
+
+Format: `ST_InteriorRingN(geom: geometry, n: Int)`
+
+Since: `v1.0.0`
+
+Spark SQL example:
+```SQL
+SELECT ST_InteriorRingN(ST_GeomFromText('POLYGON((0 0, 0 5, 5 5, 5 0, 0 0), (1 1, 2 1, 2 2, 1 2, 1 1), (1 3, 2 3, 2 4, 1 4, 1 3), (3 3, 4 3, 4 4, 3 4, 3 3))'), 0)
+```
+
+Output: `LINESTRING (1 1, 2 1, 2 2, 1 2, 1 1)`
+
+## ST_Intersection
+
+Introduction: Return the intersection geometry of A and B
+
+Format: `ST_Intersection (A:geometry, B:geometry)`
+
+Since: `v1.0.0`
+
+Spark SQL example:
+
+```SQL
+SELECT ST_Intersection(polygondf.countyshape, polygondf.countyshape)
+FROM polygondf
+```
+
+## ST_IsClosed
+
+Introduction: RETURNS true if the LINESTRING start and end point are the same.
+
+Format: `ST_IsClosed(geom: geometry)`
+
+Since: `v1.0.0`
+
+Spark SQL example:
+```SQL
+SELECT ST_IsClosed(ST_GeomFromText('LINESTRING(0 0, 1 1, 1 0)'))
+```
+
+Output: `false`
+
+## ST_IsEmpty
+
+Introduction: Test if a geometry is empty geometry
+
+Format: `ST_IsEmpty (A:geometry)`
+
+Since: `v1.2.1`
+
+Spark SQL example:
+
+```SQL
+SELECT ST_IsEmpty(polygondf.countyshape)
+FROM polygondf
+```
+
+## ST_IsRing
+
+Introduction: RETURN true if LINESTRING is ST_IsClosed and ST_IsSimple.
+
+Format: `ST_IsRing(geom: geometry)`
+
+Since: `v1.0.0`
+
+Spark SQL example:
+```SQL
+SELECT ST_IsRing(ST_GeomFromText("LINESTRING(0 0, 0 1, 1 1, 1 0, 0 0)"))
+```
+
+Output: `true`
+
+## ST_IsSimple
+
+Introduction: Test if geometry's only self-intersections are at boundary points.
+
+Format: `ST_IsSimple (A:geometry)`
+
+Since: `v1.0.0`
+
+Spark SQL example:
+
+```SQL
+SELECT ST_IsSimple(polygondf.countyshape)
+FROM polygondf
+```
+
+## ST_IsValid
+
+Introduction: Test if a geometry is well formed
+
+Format: `ST_IsValid (A:geometry)`
+
+Since: `v1.0.0`
+
+Spark SQL example:
+
+```SQL
+SELECT ST_IsValid(polygondf.countyshape)
+FROM polygondf
+```
+
+## ST_Length
+
+Introduction: Return the perimeter of A
+
+Format: ST_Length (A:geometry)
+
+Since: `v1.0.0`
+
+Spark SQL example:
+```SQL
+SELECT ST_Length(polygondf.countyshape)
+FROM polygondf
+```
+
+## ST_LineMerge
+
+Introduction: Returns a LineString formed by sewing together the constituent line work of a MULTILINESTRING.
+
+!!!note
+Only works for MULTILINESTRING. Using other geometry will return a GEOMETRYCOLLECTION EMPTY. If the MultiLineString can't be merged, the original MULTILINESTRING is returned.
+
+Format: `ST_LineMerge (A:geometry)`
+
+Since: `v1.0.0`
+
+```SQL
+SELECT ST_LineMerge(geometry)
+FROM df
+```
+
+## ST_MakePolygon
+
+Introduction: Function to convert closed linestring to polygon including holes
+
+Format: `ST_MakePolygon(geom: geometry, holes: array<geometry>)`
+
+Since: `v1.1.0`
+
+Example:
+
+Query:
+```SQL
+SELECT
+    ST_MakePolygon(
+        ST_GeomFromText('LINESTRING(7 -1, 7 6, 9 6, 9 1, 7 -1)'),
+        ARRAY(ST_GeomFromText('LINESTRING(6 2, 8 2, 8 1, 6 1, 6 2)'))
+    ) AS polygon
+```
+
+Result:
+
+```
++----------------------------------------------------------------+
+|polygon                                                         |
++----------------------------------------------------------------+
+|POLYGON ((7 -1, 7 6, 9 6, 9 1, 7 -1), (6 2, 8 2, 8 1, 6 1, 6 2))|
++----------------------------------------------------------------+
+
+```
+
+## ST_MakeValid
+
+Introduction: Given an invalid geometry, create a valid representation of the geometry.
+
+Collapsed geometries are either converted to empty (keepCollaped=true) or a valid geometry of lower dimension (keepCollapsed=false).
+Default is keepCollapsed=false.
+
+Format: `ST_MakeValid (A:geometry)`
+
+Format: `ST_MakeValid (A:geometry, keepCollapsed:Boolean)`
+
+Since: `v1.0.0`
+
+Spark SQL example:
+
+```SQL
+WITH linestring AS (
+    SELECT ST_GeomFromWKT('LINESTRING(1 1, 1 1)') AS geom
+) SELECT ST_MakeValid(geom), ST_MakeValid(geom, true) FROM linestring
+```
+
+Result:
+```
++------------------+------------------------+
+|st_makevalid(geom)|st_makevalid(geom, true)|
++------------------+------------------------+
+|  LINESTRING EMPTY|             POINT (1 1)|
++------------------+------------------------+
+```
+
+!!!note
+In Sedona up to and including version 1.2 the behaviour of ST_MakeValid was different.
+Be sure to check you code when upgrading.
+The previous implementation only worked for (multi)polygons and had a different interpretation of the second, boolean, argument.
+It would also sometimes return multiple geometries for a single geomtry input.
+
+## ST_MinimumBoundingCircle
+
+Introduction: Returns the smallest circle polygon that contains a geometry.
+
+Format: `ST_MinimumBoundingCircle(geom: geometry, [Optional] quadrantSegments:int)`
+
+Since: `v1.0.1`
+
+Spark SQL example:
+```SQL
+SELECT ST_MinimumBoundingCircle(ST_GeomFromText('POLYGON((1 1,0 0, -1 1, 1 1))'))
+```
 
 ## ST_MinimumBoundingRadius
 
@@ -765,19 +754,247 @@ Spark SQL example:
 SELECT ST_MinimumBoundingRadius(ST_GeomFromText('POLYGON((1 1,0 0, -1 1, 1 1))'))
 ```
 
+## ST_Multi
 
-## ST_MinimumBoundingCircle
+Introduction: Returns a MultiGeometry object based on the geometry input.
+ST_Multi is basically an alias for ST_Collect with one geometry.
 
-Introduction: Returns the smallest circle polygon that contains a geometry.
+Format
 
-Format: `ST_MinimumBoundingCircle(geom: geometry, [Optional] quadrantSegments:int)`
+`ST_Multi(geom: geometry)`
 
-Since: `v1.0.1`
+Since: `v1.2.0`
+
+Example:
+
+```SQL
+SELECT ST_Multi(
+    ST_GeomFromText('POINT(1 1)')
+) AS geom
+```
+
+Result:
+
+```
++---------------------------------------------------------------+
+|geom                                                           |
++---------------------------------------------------------------+
+|MULTIPOINT (1 1)                                               |
++---------------------------------------------------------------+
+```
+
+## ST_NPoints
+
+Introduction: Return points of the geometry
+
+Since: `v1.0.0`
+
+Format: `ST_NPoints (A:geometry)`
+
+```SQL
+SELECT ST_NPoints(polygondf.countyshape)
+FROM polygondf
+```
+
+## ST_NumGeometries
+
+Introduction: Returns the number of Geometries. If geometry is a GEOMETRYCOLLECTION (or MULTI*) return the number of geometries, for single geometries will return 1.
+
+Format: `ST_NumGeometries (A:geometry)`
+
+Since: `v1.0.0`
+
+```SQL
+SELECT ST_NumGeometries(df.geometry)
+FROM df
+```
+
+## ST_NumInteriorRings
+
+Introduction: RETURNS number of interior rings of polygon geometries.
+
+Format: `ST_NumInteriorRings(geom: geometry)`
+
+Since: `v1.0.0`
 
 Spark SQL example:
 ```SQL
-SELECT ST_MinimumBoundingCircle(ST_GeomFromText('POLYGON((1 1,0 0, -1 1, 1 1))'))
+SELECT ST_NumInteriorRings(ST_GeomFromText('POLYGON ((0 0, 0 5, 5 5, 5 0, 0 0), (1 1, 2 1, 2 2, 1 2, 1 1))'))
 ```
+
+Output: `1`
+
+## ST_PointN
+
+Introduction: Return the Nth point in a single linestring or circular linestring in the geometry. Negative values are counted backwards from the end of the LineString, so that -1 is the last point. Returns NULL if there is no linestring in the geometry.
+
+Format: `ST_PointN(geom: geometry, n: integer)`
+
+Since: `v1.2.1`
+
+Spark SQL example:
+```SQL
+SELECT ST_PointN(ST_GeomFromText("LINESTRING(0 0, 1 2, 2 4, 3 6)"), 2) AS geom
+```
+
+Result:
+
+```
++---------------------------------------------------------------+
+|geom                                                           |
++---------------------------------------------------------------+
+|POINT (1 2)                                                    |
++---------------------------------------------------------------+
+```
+
+## ST_PointOnSurface
+
+Introduction: Returns a POINT guaranteed to lie on the surface.
+
+Format: `ST_PointOnSurface(A:geometry)`
+
+Since: `v1.2.1`
+
+Examples:
+
+```
+SELECT ST_AsText(ST_PointOnSurface(ST_GeomFromText('POINT(0 5)')));
+ st_astext
+------------
+ POINT(0 5)
+
+SELECT ST_AsText(ST_PointOnSurface(ST_GeomFromText('LINESTRING(0 5, 0 10)')));
+ st_astext
+------------
+ POINT(0 5)
+
+SELECT ST_AsText(ST_PointOnSurface(ST_GeomFromText('POLYGON((0 0, 0 5, 5 5, 5 0, 0 0))')));
+   st_astext
+----------------
+ POINT(2.5 2.5)
+
+SELECT ST_AsText(ST_PointOnSurface(ST_GeomFromText('LINESTRING(0 5 1, 0 0 1, 0 10 2)')));
+   st_astext
+----------------
+ POINT Z(0 0 1)
+
+```
+
+## ST_PrecisionReduce
+
+Introduction: Reduce the decimals places in the coordinates of the geometry to the given number of decimal places. The last decimal place will be rounded.
+
+Format: `ST_PrecisionReduce (A:geometry, B:int)`
+
+Since: `v1.0.0`
+
+Spark SQL example:
+
+```SQL
+SELECT ST_PrecisionReduce(polygondf.countyshape, 9)
+FROM polygondf
+```
+The new coordinates will only have 9 decimal places.
+
+## ST_RemovePoint
+
+Introduction: RETURN Line with removed point at given index, position can be omitted and then last one will be removed.
+
+Format: `ST_RemovePoint(geom: geometry, position: integer)`
+
+Format: `ST_RemovePoint(geom: geometry)`
+
+Since: `v1.0.0`
+
+Spark SQL example:
+```SQL
+SELECT ST_RemovePoint(ST_GeomFromText("LINESTRING(0 0, 1 1, 1 0)"), 1)
+```
+
+Output: `LINESTRING(0 0, 1 0)`
+
+## ST_Reverse
+
+Introduction: Return the geometry with vertex order reversed
+
+Format: `ST_Reverse (A:geometry)`
+
+Since: `v1.2.1`
+
+Example:
+
+```SQL
+SELECT ST_AsText(
+    ST_Reverse(ST_GeomFromText('LINESTRING(0 0, 1 2, 2 4, 3 6)'))
+) AS geom
+```
+
+Result:
+
+```
++---------------------------------------------------------------+
+|geom                                                           |
++---------------------------------------------------------------+
+|LINESTRING (3 6, 2 4, 1 2, 0 0)                                |
++---------------------------------------------------------------+
+```
+
+## ST_SetSRID
+
+Introduction: Sets the spatial refence system identifier (SRID) of the geometry.
+
+Format: `ST_SetSRID (A:geometry, srid: Integer)`
+
+Since: `v1.1.1`
+
+Spark SQL example:
+```SQL
+SELECT ST_SetSRID(polygondf.countyshape, 3021)
+FROM polygondf
+```
+
+## ST_SimplifyPreserveTopology
+
+Introduction: Simplifies a geometry and ensures that the result is a valid geometry having the same dimension and number of components as the input,
+and with the components having the same topological relationship.
+
+Since: `v1.0.0`
+
+Format: `ST_SimplifyPreserveTopology (A:geometry, distanceTolerance: Double)`
+
+```SQL
+SELECT ST_SimplifyPreserveTopology(polygondf.countyshape, 10.0)
+FROM polygondf
+```
+
+## ST_SRID
+
+Introduction: Return the spatial refence system identifier (SRID) of the geometry.
+
+Format: `ST_SRID (A:geometry)`
+
+Since: `v1.1.1`
+
+Spark SQL example:
+```SQL
+SELECT ST_SRID(polygondf.countyshape)
+FROM polygondf
+```
+
+## ST_StartPoint
+
+Introduction: Returns first point of given linestring.
+
+Format: `ST_StartPoint(geom: geometry)`
+
+Since: `v1.0.0`
+
+Spark SQL example:
+```SQL
+SELECT ST_StartPoint(ST_GeomFromText('LINESTRING(100 150,50 60, 70 80, 160 170)'))
+```
+
+Output: `POINT(100 150)`
 
 ## ST_SubDivide
 
@@ -840,7 +1057,7 @@ Format: `ST_SubDivideExplode(geom: geometry, maxVertices: int)`
 
 Since: `v1.1.0`
 
-Example: 
+Example:
 
 Query:
 ```SQL
@@ -879,7 +1096,7 @@ Query
 select geom from geometries LATERAL VIEW ST_SubdivideExplode(geometry, 5) AS geom
 ```
 
-Result: 
+Result:
 ```
 +-----------------------------+
 |geom                         |
@@ -892,164 +1109,6 @@ Result:
 |LINESTRING(85 85, 100 100)   |
 |LINESTRING(100 100, 120 120) |
 +-----------------------------+
-```
-
-## ST_MakePolygon
-
-Introduction: Function to convert closed linestring to polygon including holes
-
-Format: `ST_MakePolygon(geom: geometry, holes: array<geometry>)`
-
-Since: `v1.1.0`
-
-Example:
-
-Query:
-```SQL
-SELECT
-    ST_MakePolygon(
-        ST_GeomFromText('LINESTRING(7 -1, 7 6, 9 6, 9 1, 7 -1)'),
-        ARRAY(ST_GeomFromText('LINESTRING(6 2, 8 2, 8 1, 6 1, 6 2)'))
-    ) AS polygon
-```
-
-Result:
-
-```
-+----------------------------------------------------------------+
-|polygon                                                         |
-+----------------------------------------------------------------+
-|POLYGON ((7 -1, 7 6, 9 6, 9 1, 7 -1), (6 2, 8 2, 8 1, 6 1, 6 2))|
-+----------------------------------------------------------------+
-
-```
-
-
-## ST_GeoHash
-
-Introduction: Returns GeoHash of the geometry with given precision
-
-Format: `ST_GeoHash(geom: geometry, precision: int)`
-
-Since: `v1.1.1`
-
-Example: 
-
-Query:
-
-```SQL
-SELECT ST_GeoHash(ST_GeomFromText('POINT(21.427834 52.042576573)'), 5) AS geohash
-```
-
-Result:
-
-```
-+-----------------------------+
-|geohash                      |
-+-----------------------------+
-|u3r0p                        |
-+-----------------------------+
-```
-
-## ST_Collect
-
-Introduction: Returns MultiGeometry object based on geometry column/s or array with geometries
-
-Format 
-
-`ST_Collect(*geom: geometry)`
-
-`ST_Collect(geom: array<geometry>)`
-
-Since: `v1.2.0`
-
-Example: 
-
-```SQL
-SELECT ST_Collect(
-    ST_GeomFromText('POINT(21.427834 52.042576573)'),
-    ST_GeomFromText('POINT(45.342524 56.342354355)')
-) AS geom
-```
-
-Result:
-
-```
-+---------------------------------------------------------------+
-|geom                                                           |
-+---------------------------------------------------------------+
-|MULTIPOINT ((21.427834 52.042576573), (45.342524 56.342354355))|
-+---------------------------------------------------------------+
-```
-
-Example:
-
-```SQL
-SELECT ST_Collect(
-    Array(
-        ST_GeomFromText('POINT(21.427834 52.042576573)'),
-        ST_GeomFromText('POINT(45.342524 56.342354355)')
-    )
-) AS geom
-```
-
-Result:
-
-```
-+---------------------------------------------------------------+
-|geom                                                           |
-+---------------------------------------------------------------+
-|MULTIPOINT ((21.427834 52.042576573), (45.342524 56.342354355))|
-+---------------------------------------------------------------+
-```
-
-## ST_Multi
-
-Introduction: Returns a MultiGeometry object based on the geometry input.
-ST_Multi is basically an alias for ST_Collect with one geometry.
-
-Format
-
-`ST_Multi(geom: geometry)`
-
-Since: `v1.2.0`
-
-Example:
-
-```SQL
-SELECT ST_Multi(
-    ST_GeomFromText('POINT(1 1)')
-) AS geom
-```
-
-Result:
-
-```
-+---------------------------------------------------------------+
-|geom                                                           |
-+---------------------------------------------------------------+
-|MULTIPOINT (1 1)                                               |
-+---------------------------------------------------------------+
-```
-
-## ST_Difference
-
-Introduction: Return the difference between geometry A and B (return part of geometry A that does not intersect geometry B)
-
-Format: `ST_Difference (A:geometry, B:geometry)`
-
-Since: `v1.2.0`
-
-Example:
-
-```SQL
-SELECT ST_Difference(ST_GeomFromWKT('POLYGON ((-3 -3, 3 -3, 3 3, -3 3, -3 -3))'), ST_GeomFromWKT('POLYGON ((0 -4, 4 -4, 4 4, 0 4, 0 -4))'))
-```
-
-Result:
-
-```
-POLYGON ((0 -3, -3 -3, -3 3, 0 3, 0 -3))
 ```
 
 ## ST_SymDifference
@@ -1073,6 +1132,37 @@ Result:
 MULTIPOLYGON (((-2 -3, -3 -3, -3 3, -2 3, -2 -3)), ((3 -3, 3 3, 4 3, 4 -3, 3 -3)))
 ```
 
+## ST_Transform
+
+Introduction:
+
+Transform the Spatial Reference System / Coordinate Reference System of A, from SourceCRS to TargetCRS
+
+!!!note
+	By default, this function uses lat/lon order. You can use ==ST_FlipCoordinates== to swap X and Y.
+
+!!!note
+	If ==ST_Transform== throws an Exception called "Bursa wolf parameters required", you need to disable the error notification in ST_Transform. You can append a boolean value at the end.
+
+Format: `ST_Transform (A:geometry, SourceCRS:string, TargetCRS:string ,[Optional] DisableError)`
+
+Since: `v1.0.0`
+
+Spark SQL example (simple):
+```SQL
+SELECT ST_Transform(polygondf.countyshape, 'epsg:4326','epsg:3857') 
+FROM polygondf
+```
+
+Spark SQL example (with optional parameters):
+```SQL
+SELECT ST_Transform(polygondf.countyshape, 'epsg:4326','epsg:3857', false)
+FROM polygondf
+```
+
+!!!note
+	The detailed EPSG information can be searched on [EPSG.io](https://epsg.io/).
+
 ## ST_Union
 
 Introduction: Return the union of geometry A and B
@@ -1094,113 +1184,20 @@ Result:
 POLYGON ((3 -1, 3 -3, -3 -3, -3 3, 3 3, 3 1, 5 0, 3 -1))
 ```
 
-## ST_PointOnSurface
+## ST_X
 
-Introduction: Returns a POINT guaranteed to lie on the surface.
+Introduction: Returns X Coordinate of given Point null otherwise.
 
-Format: `ST_PointOnSurface(A:geometry)`
+Format: `ST_X(pointA: Point)`
 
-Since: `v1.2.1`
-
-Examples: 
-
-```
-SELECT ST_AsText(ST_PointOnSurface(ST_GeomFromText('POINT(0 5)')));
- st_astext
-------------
- POINT(0 5)
-
-SELECT ST_AsText(ST_PointOnSurface(ST_GeomFromText('LINESTRING(0 5, 0 10)')));
- st_astext
-------------
- POINT(0 5)
-
-SELECT ST_AsText(ST_PointOnSurface(ST_GeomFromText('POLYGON((0 0, 0 5, 5 5, 5 0, 0 0))')));
-   st_astext
-----------------
- POINT(2.5 2.5)
-
-SELECT ST_AsText(ST_PointOnSurface(ST_GeomFromText('LINESTRING(0 5 1, 0 0 1, 0 10 2)')));
-   st_astext
-----------------
- POINT Z(0 0 1)
-
-```
-
-## ST_Reverse
-
-Introduction: Return the geometry with vertex order reversed
-
-Format: `ST_Reverse (A:geometry)`
-
-Since: `v1.2.1`
-
-Example:
-
-```SQL
-SELECT ST_AsText(
-    ST_Reverse(ST_GeomFromText('LINESTRING(0 0, 1 2, 2 4, 3 6)'))
-) AS geom
-```
-
-Result:
-
-```
-+---------------------------------------------------------------+
-|geom                                                           |
-+---------------------------------------------------------------+
-|LINESTRING (3 6, 2 4, 1 2, 0 0)                                |
-+---------------------------------------------------------------+
-```
-
-## ST_PointN
-
-Introduction: Return the Nth point in a single linestring or circular linestring in the geometry. Negative values are counted backwards from the end of the LineString, so that -1 is the last point. Returns NULL if there is no linestring in the geometry.
-
-Format: `ST_PointN(geom: geometry, n: integer)`
-
-Since: `v1.2.1`
+Since: `v1.0.0`
 
 Spark SQL example:
 ```SQL
-SELECT ST_PointN(ST_GeomFromText("LINESTRING(0 0, 1 2, 2 4, 3 6)"), 2) AS geom
+SELECT ST_X(ST_POINT(0.0 25.0))
 ```
 
-Result:
-
-```
-+---------------------------------------------------------------+
-|geom                                                           |
-+---------------------------------------------------------------+
-|POINT (1 2)                                                    |
-+---------------------------------------------------------------+
-```
-
-## ST_Force_2D
-
-Introduction: Forces the geometries into a "2-dimensional mode" so that all output representations will only have the X and Y coordinates
-
-Format: `ST_Force_2D (A:geometry)`
-
-Since: `v1.2.1`
-
-Example:
-
-```SQL
-SELECT ST_AsText(
-    ST_Force_2D(ST_GeomFromText('POLYGON((0 0 2,0 5 2,5 0 2,0 0 2),(1 1 2,3 1 2,1 3 2,1 1 2))'))
-) AS geom
-```
-
-Result:
-
-```
-+---------------------------------------------------------------+
-|geom                                                           |
-+---------------------------------------------------------------+
-|POLYGON((0 0,0 5,5 0,0 0),(1 1,3 1,1 3,1 1))                   |
-+---------------------------------------------------------------+
-```
+Output: `0.0`
 
 ## ST_XMax
 
@@ -1240,69 +1237,62 @@ Input: `POLYGON ((-1 -11, 0 10, 1 11, 2 12, -1 -11))`
 
 Output: `-1`
 
-## ST_BuildArea
+## ST_Y
 
-Introduction: Returns the areal geometry formed by the constituent linework of the input geometry.
+Introduction: Returns Y Coordinate of given Point, null otherwise.
 
-Format: `ST_BuildArea (A:geometry)`
+Format: `ST_Y(pointA: Point)`
+
+Since: `v1.0.0`
+
+Spark SQL example:
+```SQL
+SELECT ST_Y(ST_POINT(0.0 25.0))
+```
+
+Output: `25.0`
+
+## ST_YMax
+
+Introduction: Return the minimum Y coordinate of A
+
+Format: `ST_YMax (A:geometry)`
 
 Since: `v1.2.1`
 
-Example:
-
+Spark SQL example:
 ```SQL
-SELECT ST_BuildArea(
-    ST_GeomFromText('MULTILINESTRING((0 0, 20 0, 20 20, 0 20, 0 0),(2 2, 18 2, 18 18, 2 18, 2 2))')
-) AS geom
+SELECT ST_YMax(ST_GeomFromText('POLYGON((0 0 1, 1 1 1, 1 2 1, 1 1 1, 0 0 1))'))
 ```
 
-Result:
+Output: 2
 
-```
+## ST_YMin
 
-+----------------------------------------------------------------------------+
-|geom                                                                        |
-+----------------------------------------------------------------------------+
-|POLYGON((0 0,0 20,20 20,20 0,0 0),(2 2,18 2,18 18,2 18,2 2))                |
-+----------------------------------------------------------------------------+
-```
+Introduction: Return the minimum Y coordinate of A
 
-## ST_CollectionExtract
-
-Introduction: Returns a homogeneous multi-geometry from a given geometry collection.
-
-The type numbers are: 
-1. POINT
-2. LINESTRING
-3. POLYGON
-
-If the type parameter is omitted a multi-geometry of the highest dimension is returned.
-
-Format: `ST_CollectionExtract (A:geometry)`
-
-Format: `ST_CollectionExtract (A:geometry, type:Int)`
+Format: `ST_Y_Min (A:geometry)`
 
 Since: `v1.2.1`
 
-Example:
-
+Spark SQL example:
 ```SQL
-WITH test_data as (
-    ST_GeomFromText(
-        'GEOMETRYCOLLECTION(POINT(40 10), POLYGON((0 0, 0 5, 5 5, 5 0, 0 0)))'
-    ) as geom
-)
-SELECT ST_CollectionExtract(geom) as c1, ST_CollectionExtract(geom, 1) as c2 
-FROM test_data
-
+SELECT ST_YMin(ST_GeomFromText('POLYGON((0 0 1, 1 1 1, 1 2 1, 1 1 1, 0 0 1))'))
 ```
 
-Result:
+Output : 0
 
+## ST_Z
+
+Introduction: Returns Z Coordinate of given Point, null otherwise.
+
+Format: `ST_Z(pointA: Point)`
+
+Since: `v1.2.0`
+
+Spark SQL example:
+```SQL
+SELECT ST_Z(ST_POINT(0.0 25.0 11.0))
 ```
-+----------------------------------------------------------------------------+
-|c1                                        |c2                               |
-+----------------------------------------------------------------------------+
-|MULTIPOLYGON(((0 0, 0 5, 5 5, 5 0, 0 0))) |MULTIPOINT(40 10)                |              |
-+----------------------------------------------------------------------------+
-```
+
+Output: `11.0`

--- a/docs/api/sql/Parameter.md
+++ b/docs/api/sql/Parameter.md
@@ -28,14 +28,14 @@ println(sedonaConf)
 	* Spatial partitioning grid type for join query
 	* Default: kdbtree
 	* Possible values: quadtree, kdbtree
-* sedona.join.numpartition **(Advanced users only!)**
-	* Number of partitions for both sides in a join query
-	* Default: -1, which means use the existing partitions
-	* Possible values: any integers
 * sedona.join.indexbuildside **(Advanced users only!)**
 	* The side which Sedona builds spatial indices on
 	* Default: left
 	* Possible values: left, right
+* sedona.join.numpartition **(Advanced users only!)**
+	* Number of partitions for both sides in a join query
+	* Default: -1, which means use the existing partitions
+	* Possible values: any integers
 * sedona.join.spatitionside **(Advanced users only!)**
 	* The dominant side in spatial partitioning stage
 	* Default: left

--- a/docs/api/sql/Predicate.md
+++ b/docs/api/sql/Predicate.md
@@ -13,11 +13,11 @@ FROM pointdf
 WHERE ST_Contains(ST_PolygonFromEnvelope(1.0,100.0,1000.0,1100.0), pointdf.arealandmark)
 ```
 
-## ST_Intersects
+## ST_Crosses
 
-Introduction: Return true if A intersects B
+Introduction: Return true if A crosses B
 
-Format: `ST_Intersects (A:geometry, B:geometry)`
+Format: `ST_Crosses (A:geometry, B:geometry)`
 
 Since: `v1.0.0`
 
@@ -25,22 +25,22 @@ Spark SQL example:
 ```SQL
 SELECT * 
 FROM pointdf 
-WHERE ST_Intersects(ST_PolygonFromEnvelope(1.0,100.0,1000.0,1100.0), pointdf.arealandmark)
+WHERE ST_Crosses(pointdf.arealandmark, ST_PolygonFromEnvelope(1.0,100.0,1000.0,1100.0))
 ```
 
-## ST_Within
+## ST_Disjoint
 
-Introduction: Return true if A is fully contained by B
+Introduction: Return true if A and B are disjoint
 
-Format: `ST_Within (A:geometry, B:geometry)`
+Format: `ST_Disjoint (A:geometry, B:geometry)`
 
-Since: `v1.0.0`
+Since: `v1.2.1`
 
 Spark SQL example:
 ```SQL
-SELECT * 
-FROM pointdf 
-WHERE ST_Within(pointdf.arealandmark, ST_PolygonFromEnvelope(1.0,100.0,1000.0,1100.0))
+SELECT *
+FROM geom
+WHERE ST_Disjoinnt(geom.geom_a, geom.geom_b)
 ```
 
 ## ST_Equals
@@ -58,11 +58,11 @@ FROM pointdf
 WHERE ST_Equals(pointdf.arealandmark, ST_PolygonFromEnvelope(1.0,100.0,1000.0,1100.0))
 ```
 
-## ST_Crosses
+## ST_Intersects
 
-Introduction: Return true if A crosses B
+Introduction: Return true if A intersects B
 
-Format: `ST_Crosses (A:geometry, B:geometry)`
+Format: `ST_Intersects (A:geometry, B:geometry)`
 
 Since: `v1.0.0`
 
@@ -70,51 +70,7 @@ Spark SQL example:
 ```SQL
 SELECT * 
 FROM pointdf 
-WHERE ST_Crosses(pointdf.arealandmark, ST_PolygonFromEnvelope(1.0,100.0,1000.0,1100.0))
-```
-
-## ST_Touches
-
-Introduction: Return true if A touches B
-
-Format: `ST_Touches (A:geometry, B:geometry)`
-
-Since: `v1.0.0`
-
-```SQL
-SELECT * 
-FROM pointdf 
-WHERE ST_Touches(pointdf.arealandmark, ST_PolygonFromEnvelope(1.0,100.0,1000.0,1100.0))
-```
-
-## ST_Overlaps
-
-Introduction: Return true if A overlaps B
-
-Format: `ST_Overlaps (A:geometry, B:geometry)`
-
-Since: `v1.0.0`
-
-Spark SQL example:
-```SQL
-SELECT *
-FROM geom
-WHERE ST_Overlaps(geom.geom_a, geom.geom_b)
-```
-
-## ST_Disjoint
-
-Introduction: Return true if A and B are disjoint
-
-Format: `ST_Disjoint (A:geometry, B:geometry)`
-
-Since: `v1.2.1`
-
-Spark SQL example:
-```SQL
-SELECT *
-FROM geom
-WHERE ST_Disjoinnt(geom.geom_a, geom.geom_b)
+WHERE ST_Intersects(ST_PolygonFromEnvelope(1.0,100.0,1000.0,1100.0), pointdf.arealandmark)
 ```
 
 ## ST_OrderingEquals
@@ -137,3 +93,47 @@ SELECT ST_OrderingEquals(ST_GeomFromWKT('POLYGON((2 0, 0 2, -2 0, 2 0))'), ST_Ge
 ```
 
 Output: `false`
+
+## ST_Overlaps
+
+Introduction: Return true if A overlaps B
+
+Format: `ST_Overlaps (A:geometry, B:geometry)`
+
+Since: `v1.0.0`
+
+Spark SQL example:
+```SQL
+SELECT *
+FROM geom
+WHERE ST_Overlaps(geom.geom_a, geom.geom_b)
+```
+
+## ST_Touches
+
+Introduction: Return true if A touches B
+
+Format: `ST_Touches (A:geometry, B:geometry)`
+
+Since: `v1.0.0`
+
+```SQL
+SELECT * 
+FROM pointdf 
+WHERE ST_Touches(pointdf.arealandmark, ST_PolygonFromEnvelope(1.0,100.0,1000.0,1100.0))
+```
+
+## ST_Within
+
+Introduction: Return true if A is fully contained by B
+
+Format: `ST_Within (A:geometry, B:geometry)`
+
+Since: `v1.0.0`
+
+Spark SQL example:
+```SQL
+SELECT * 
+FROM pointdf 
+WHERE ST_Within(pointdf.arealandmark, ST_PolygonFromEnvelope(1.0,100.0,1000.0,1100.0))
+```

--- a/docs/api/sql/Raster-loader.md
+++ b/docs/api/sql/Raster-loader.md
@@ -1,4 +1,4 @@
-### Geotiff Dataframe Loader
+## Geotiff Dataframe Loader
 
 Introduction: The GeoTiff loader of Sedona is a Spark built-in data source. It can read a single geotiff image or 
 a number of geotiff images into a DataFrame.
@@ -74,103 +74,6 @@ Output:
 |file:///home/hp/D...|POLYGON ((-58.699...|    32|   32|[1058.0, 1039.0, ...|    4|
 |file:///home/hp/D...|POLYGON ((-58.297...|    32|   32|[1258.0, 1298.0, ...|    4|
 +--------------------+--------------------+------+-----+--------------------+-----+
-```
-
-## RS_GetBand
-
-Introduction: Return a particular band from Geotiff Dataframe
-
-The number of total bands can be obtained from the GeoTiff loader
-
-Format: `RS_GetBand (allBandValues: Array[Double], targetBand:Int, totalBands:Int)`
-
-Since: `v1.1.0`
-
-!!!note
-	Index of targetBand starts from 1 (instead of 0). Index of the first band is 1.
-
-Spark SQL example:
-
-```Scala
-val BandDF = spark.sql("select RS_GetBand(data, 2, Band) as targetBand from GeotiffDataframe")
-BandDF.show()
-```
-
-Output:
-
-```html
-+--------------------+
-|          targetBand|
-+--------------------+
-|[1058.0, 1039.0, ...|
-|[1258.0, 1298.0, ...|
-+--------------------+
-```
-
-## RS_Array
-
-Introduction: Create an array that is filled by the given value
-
-Format: `RS_Array(length:Int, value: Decimal)`
-
-Since: `v1.1.0`
-
-Spark SQL example:
-
-```Scala
-SELECT RS_Array(height * width, 0.0)
-```
-
-## RS_Base64
-
-Introduction: Return a Base64 String from a geotiff image
-
-Format: `RS_Base64 (height:Int, width:Int, redBand: Array[Double], greenBand: Array[Double], blackBand: Array[Double], 
-optional: alphaBand: Array[Double])`
-
-Since: `v1.1.0`
-
-Spark SQL example:
-```Scala
-val BandDF = spark.sql("select RS_Base64(h, w, band1, band2, RS_Array(h*w, 0)) as baseString from dataframe")
-BandDF.show()
-```
-
-Output:
-
-```html
-+--------------------+
-|          baseString|
-+--------------------+
-|QJCIAAAAAABAkDwAA...|
-|QJOoAAAAAABAlEgAA...|
-+--------------------+
-```
-
-!!!note
-	Although the 3 RGB bands are mandatory, you can use [RS_Array(h*w, 0.0)](#rs_array) to create an array (zeroed out, size = h * w) as input.
-
-## RS_HTML
-
-Introduction: Return a html img tag with the base64 string embedded
-
-Format: `RS_HTML(base64:String, optional: width_in_px:String)`
-
-Spark SQL example:
-
-```Scala
-df.selectExpr("RS_HTML(encodedstring, '300') as htmlstring" ).show()
-```
-
-Output:
-
-```html
-+--------------------+
-|          htmlstring|
-+--------------------+
-|<img src="data:im...|
-|<img src="data:im...|
-+--------------------+
 ```
 
 ## Geotiff Dataframe Writer
@@ -251,4 +154,101 @@ An example:
 dfToWrite = sparkSession.read.format("geotiff").option("dropInvalid", true).option("readToCRS", "EPSG:4326").load("PATH_TO_INPUT_GEOTIFF_IMAGES")
 dfToWrite = dfToWrite.selectExpr("image.origin as source","ST_GeomFromWkt(image.geometry) as geom", "image.height as height", "image.width as width", "image.data as data", "image.nBands as bands")
 dfToWrite.write.mode("overwrite").format("geotiff").option("writeToCRS", "EPSG:4326").option("fieldOrigin", "source").option("fieldGeometry", "geom").option("fieldNBands", "bands").save("DESTINATION_PATH")
+```
+
+## RS_Array
+
+Introduction: Create an array that is filled by the given value
+
+Format: `RS_Array(length:Int, value: Decimal)`
+
+Since: `v1.1.0`
+
+Spark SQL example:
+
+```Scala
+SELECT RS_Array(height * width, 0.0)
+```
+
+## RS_Base64
+
+Introduction: Return a Base64 String from a geotiff image
+
+Format: `RS_Base64 (height:Int, width:Int, redBand: Array[Double], greenBand: Array[Double], blackBand: Array[Double],
+optional: alphaBand: Array[Double])`
+
+Since: `v1.1.0`
+
+Spark SQL example:
+```Scala
+val BandDF = spark.sql("select RS_Base64(h, w, band1, band2, RS_Array(h*w, 0)) as baseString from dataframe")
+BandDF.show()
+```
+
+Output:
+
+```html
++--------------------+
+|          baseString|
++--------------------+
+|QJCIAAAAAABAkDwAA...|
+|QJOoAAAAAABAlEgAA...|
++--------------------+
+```
+
+!!!note
+Although the 3 RGB bands are mandatory, you can use [RS_Array(h*w, 0.0)](#rs_array) to create an array (zeroed out, size = h * w) as input.
+
+## RS_GetBand
+
+Introduction: Return a particular band from Geotiff Dataframe
+
+The number of total bands can be obtained from the GeoTiff loader
+
+Format: `RS_GetBand (allBandValues: Array[Double], targetBand:Int, totalBands:Int)`
+
+Since: `v1.1.0`
+
+!!!note
+	Index of targetBand starts from 1 (instead of 0). Index of the first band is 1.
+
+Spark SQL example:
+
+```Scala
+val BandDF = spark.sql("select RS_GetBand(data, 2, Band) as targetBand from GeotiffDataframe")
+BandDF.show()
+```
+
+Output:
+
+```html
++--------------------+
+|          targetBand|
++--------------------+
+|[1058.0, 1039.0, ...|
+|[1258.0, 1298.0, ...|
++--------------------+
+```
+
+## RS_HTML
+
+Introduction: Return a html img tag with the base64 string embedded
+
+Format: `RS_HTML(base64:String, optional: width_in_px:String)`
+
+Spark SQL example:
+
+```Scala
+df.selectExpr("RS_HTML(encodedstring, '300') as htmlstring" ).show()
+```
+
+Output:
+
+```html
++--------------------+
+|          htmlstring|
++--------------------+
+|<img src="data:im...|
+|<img src="data:im...|
++--------------------+
 ```

--- a/docs/api/sql/Raster-operators.md
+++ b/docs/api/sql/Raster-operators.md
@@ -13,108 +13,48 @@ val sumDF = spark.sql("select RS_Add(band1, band2) as sumOfBands from dataframe"
 
 ```
 
-## RS_Subtract
+## RS_Append
 
-Introduction: Subtract two spectral bands in a Geotiff image(band2 - band1)
+Introduction: Appends a new band to the end of Geotiff image data and returns the new data. The new band to be appended can be a normalized difference index between two bands (example: NBR, NDBI). Normalized difference index between two bands can be calculated with RS_NormalizedDifference operator described earlier in this page. Specific bands can be retrieved using RS_GetBand operator described [here](../Raster-loader/).
 
-Format: `RS_Subtract (Band1: Array[Double], Band2: Array[Double])`
+Format: `RS_Append(data: Array[Double], newBand: Array[Double], nBands: Int)`
 
-Since: `v1.1.0`
+Since: `v1.2.1`
 
 Spark SQL example:
 ```Scala
 
-val subtractDF = spark.sql("select RS_Subtract(band1, band2) as differenceOfOfBands from dataframe")
+val dfAppended = spark.sql("select RS_Append(data, normalizedDifference, nBands) as dataEdited from dataframe")
 
 ```
 
-## RS_Multiply
+## RS_BitwiseAND
 
-Introduction: Multiply two spectral bands in a Geotiff image
+Introduction: Find Bitwise AND between two bands of Geotiff image
 
-Format: `RS_Multiply (Band1: Array[Double], Band2: Array[Double])`
+Format: `RS_BitwiseAND (Band1: Array[Double], Band2: Array[Double])`
 
 Since: `v1.1.0`
 
 Spark SQL example:
 ```Scala
 
-val multiplyDF = spark.sql("select RS_Multiply(band1, band2) as multiplyBands from dataframe")
+val biwiseandDF = spark.sql("select RS_BitwiseAND(band1, band2) as andvalue from dataframe")
 
 ```
 
-## RS_Divide
+## RS_BitwiseOR
 
-Introduction: Divide band1 with band2 from a geotiff image
+Introduction: Find Bitwise OR between two bands of Geotiff image
 
-Format: `RS_Divide (Band1: Array[Double], Band2: Array[Double])`
-
-Since: `v1.1.0`
-
-Spark SQL example:
-```Scala
-
-val multiplyDF = spark.sql("select RS_Divide(band1, band2) as divideBands from dataframe")
-
-```
-
-## RS_MultiplyFactor
-
-Introduction: Multiply a factor to a spectral band in a geotiff image
-
-Format: `RS_MultiplyFactor (Band1: Array[Double], Factor: Int)`
+Format: `RS_BitwiseOR (Band1: Array[Double], Band2: Array[Double])`
 
 Since: `v1.1.0`
 
 Spark SQL example:
 ```Scala
 
-val multiplyFactorDF = spark.sql("select RS_MultiplyFactor(band1, 2) as multiplyfactor from dataframe")
-
-```
-
-## RS_Mode
-
-Introduction: Returns Mode from a spectral band in a Geotiff image in form of an array
-
-Format: `RS_Mode (Band: Array[Double])`
-
-Since: `v1.1.0`
-
-Spark SQL example:
-```Scala
-
-val modeDF = spark.sql("select RS_Mode(band) as mode from dataframe")
-
-```
-
-## RS_Mean
-
-Introduction: Returns Mean value for a spectral band in a Geotiff image
-
-Format: `RS_Mean (Band: Array[Double])`
-
-Since: `v1.1.0`
-
-Spark SQL example:
-```Scala
-
-val meanDF = spark.sql("select RS_Mean(band) as mean from dataframe")
-
-```
-
-## RS_NormalizedDifference
-
-Introduction: Returns Normalized Difference between two bands(band2 and band1) in a Geotiff image(example: NDVI, NDBI) 
-
-Format: `RS_NormalizedDifference (Band1: Array[Double], Band2: Array[Double])`
-
-Since: `v1.1.0`
-
-Spark SQL example:
-```Scala
-
-val normalizedDF = spark.sql("select RS_NormalizedDifference(band1, band2) as normdifference from dataframe")
+val biwiseorDF = spark.sql("select RS_BitwiseOR(band1, band2) as or from dataframe")
 
 ```
 
@@ -133,9 +73,38 @@ val countDF = spark.sql("select RS_Count(band1, target) as count from dataframe"
 
 ```
 
+## RS_Divide
+
+Introduction: Divide band1 with band2 from a geotiff image
+
+Format: `RS_Divide (Band1: Array[Double], Band2: Array[Double])`
+
+Since: `v1.1.0`
+
+Spark SQL example:
+```Scala
+
+val multiplyDF = spark.sql("select RS_Divide(band1, band2) as divideBands from dataframe")
+
+```
+
+## RS_FetchRegion
+
+Introduction: Fetch a subset of region from given Geotiff image based on minimumX, minimumY, maximumX and maximumY index as well original height and width of image
+
+Format: `RS_FetchRegion (Band: Array[Double], coordinates: Array[Int], dimenstions: Array[Int])`
+
+Since: `v1.1.0`
+
+Spark SQL example:
+```Scala
+
+val region = spark.sql("select RS_FetchRegion(Band,Array(0, 0, 1, 2),Array(3, 3)) as Region from dataframe")
+```
+
 ## RS_GreaterThan
 
-Introduction: Mask all the values with 1 which are greater than a particular target value 
+Introduction: Mask all the values with 1 which are greater than a particular target value
 
 Format: `RS_GreaterThan (Band: Array[Double], Target: Double)`
 
@@ -193,6 +162,66 @@ val lessEqualDF = spark.sql("select RS_LessThanEqual(band, target) as maskedvalu
 
 ```
 
+## RS_LogicalDifference
+
+Introduction: Return value from band 1 if a value in band1 and band2 are different, else return 0
+
+Format: `RS_LogicalDifference (Band1: Array[Double], Band2: Array[Double])`
+
+Since: `v1.1.0`
+
+Spark SQL example:
+```Scala
+
+val logicalDifference = spark.sql("select RS_LogicalDifference(band1, band2) as logdifference from dataframe")
+
+```
+
+## RS_LogicalOver
+
+Introduction: Return value from band1 if it's not equal to 0, else return band2 value
+
+Format: `RS_LogicalOver (Band1: Array[Double], Band2: Array[Double])`
+
+Since: `v1.1.0`
+
+Spark SQL example:
+```Scala
+
+val logicalOver = spark.sql("select RS_LogicalOver(band1, band2) as logover from dataframe")
+
+```
+
+## RS_Mean
+
+Introduction: Returns Mean value for a spectral band in a Geotiff image
+
+Format: `RS_Mean (Band: Array[Double])`
+
+Since: `v1.1.0`
+
+Spark SQL example:
+```Scala
+
+val meanDF = spark.sql("select RS_Mean(band) as mean from dataframe")
+
+```
+
+## RS_Mode
+
+Introduction: Returns Mode from a spectral band in a Geotiff image in form of an array
+
+Format: `RS_Mode (Band: Array[Double])`
+
+Since: `v1.1.0`
+
+Spark SQL example:
+```Scala
+
+val modeDF = spark.sql("select RS_Mode(band) as mode from dataframe")
+
+```
+
 ## RS_Modulo
 
 Introduction: Find modulo of pixels with respect to a particular value
@@ -208,33 +237,59 @@ val moduloDF = spark.sql("select RS_Modulo(band, target) as modulo from datafram
 
 ```
 
-## RS_BitwiseAND
+## RS_Multiply
 
-Introduction: Find Bitwise AND between two bands of Geotiff image
+Introduction: Multiply two spectral bands in a Geotiff image
 
-Format: `RS_BitwiseAND (Band1: Array[Double], Band2: Array[Double])`
+Format: `RS_Multiply (Band1: Array[Double], Band2: Array[Double])`
 
 Since: `v1.1.0`
 
 Spark SQL example:
 ```Scala
 
-val biwiseandDF = spark.sql("select RS_BitwiseAND(band1, band2) as andvalue from dataframe")
+val multiplyDF = spark.sql("select RS_Multiply(band1, band2) as multiplyBands from dataframe")
 
 ```
 
-## RS_BitwiseOR
+## RS_MultiplyFactor
 
-Introduction: Find Bitwise OR between two bands of Geotiff image
+Introduction: Multiply a factor to a spectral band in a geotiff image
 
-Format: `RS_BitwiseOR (Band1: Array[Double], Band2: Array[Double])`
+Format: `RS_MultiplyFactor (Band1: Array[Double], Factor: Int)`
 
 Since: `v1.1.0`
 
 Spark SQL example:
 ```Scala
 
-val biwiseorDF = spark.sql("select RS_BitwiseOR(band1, band2) as or from dataframe")
+val multiplyFactorDF = spark.sql("select RS_MultiplyFactor(band1, 2) as multiplyfactor from dataframe")
+
+```
+
+## RS_Normalize
+
+Introduction: Normalize the value in the array to [0, 255]
+
+Since: `v1.1.0`
+
+Spark SQL example
+```SQL
+SELECT RS_Normalize(band)
+```
+
+## RS_NormalizedDifference
+
+Introduction: Returns Normalized Difference between two bands(band2 and band1) in a Geotiff image(example: NDVI, NDBI)
+
+Format: `RS_NormalizedDifference (Band1: Array[Double], Band2: Array[Double])`
+
+Since: `v1.1.0`
+
+Spark SQL example:
+```Scala
+
+val normalizedDF = spark.sql("select RS_NormalizedDifference(band1, band2) as normdifference from dataframe")
 
 ```
 
@@ -253,74 +308,17 @@ val rootDF = spark.sql("select RS_SquareRoot(band) as squareroot from dataframe"
 
 ```
 
-## RS_LogicalDifference
+## RS_Subtract
 
-Introduction: Return value from band 1 if a value in band1 and band2 are different, else return 0
+Introduction: Subtract two spectral bands in a Geotiff image(band2 - band1)
 
-Format: `RS_LogicalDifference (Band1: Array[Double], Band2: Array[Double])`
-
-Since: `v1.1.0`
-
-Spark SQL example:
-```Scala
-
-val logicalDifference = spark.sql("select RS_LogicalDifference(band1, band2) as logdifference from dataframe")
-
-```
-
-## RS_LogicalOver
-
-Introduction: Return value from band1 if it's not equal to 0, else return band2 value 
-
-Format: `RS_LogicalOver (Band1: Array[Double], Band2: Array[Double])`
+Format: `RS_Subtract (Band1: Array[Double], Band2: Array[Double])`
 
 Since: `v1.1.0`
 
 Spark SQL example:
 ```Scala
 
-val logicalOver = spark.sql("select RS_LogicalOver(band1, band2) as logover from dataframe")
+val subtractDF = spark.sql("select RS_Subtract(band1, band2) as differenceOfOfBands from dataframe")
 
 ```
-
-## RS_FetchRegion
-
-Introduction: Fetch a subset of region from given Geotiff image based on minimumX, minimumY, maximumX and maximumY index as well original height and width of image
-
-Format: `RS_FetchRegion (Band: Array[Double], coordinates: Array[Int], dimenstions: Array[Int])`
-
-Since: `v1.1.0`
-
-Spark SQL example:
-```Scala
-
-val region = spark.sql("select RS_FetchRegion(Band,Array(0, 0, 1, 2),Array(3, 3)) as Region from dataframe")
-```
-
-## RS_Normalize
-
-Introduction: Normalize the value in the array to [0, 255]
-
-Since: `v1.1.0`
-
-Spark SQL example
-```SQL
-SELECT RS_Normalize(band)
-```
-
-## RS_Append
-
-Introduction: Appends a new band to the end of Geotiff image data and returns the new data. The new band to be appended can be a normalized difference index between two bands (example: NBR, NDBI). Normalized difference index between two bands can be calculated with RS_NormalizedDifference operator described earlier in this page. Specific bands can be retrieved using RS_GetBand operator described [here](../Raster-loader/).
-
-Format: `RS_Append(data: Array[Double], newBand: Array[Double], nBands: Int)`
-
-Since: `v1.2.1`
-
-Spark SQL example:
-```Scala
-
-val dfAppended = spark.sql("select RS_Append(data, normalizedDifference, nBands) as dataEdited from dataframe")
-
-```
-
-

--- a/docs/api/viz/sql.md
+++ b/docs/api/viz/sql.md
@@ -18,45 +18,12 @@ SedonaVizRegistrator.registerAll(sparkSession)
 
 ## Regular functions
 
-### ST_Pixelize
-
-Introduction: Convert a geometry to an array of pixels given a resolution
-
-You should use it together with `Lateral View` and `Explode`
-
-Format: `ST_Pixelize (A:geometry, ResolutionX:int, ResolutionY:int, Boundary:geometry)`
-
-Since: `v1.0.0`
-
-Spark SQL example:
-```SQL
-SELECT ST_Pixelize(shape, 256, 256, (ST_Envelope_Aggr(shape) FROM pointtable))
-FROM polygondf
-```
-
-### ST_TileName
-
-Introduction: Return the map tile name for a given zoom level. Please refer to [OpenStreetMap ZoomLevel](http://wiki.openstreetmap.org/wiki/Zoom_levels) and [OpenStreetMap tile name](https://wiki.openstreetmap.org/wiki/Slippy_map_tilenames).
-
-!!!note
-	Tile name is formatted as a "Z-X-Y" string. Z is zoom level. X is tile coordinate on X axis. Y is tile coordinate on Y axis.
-
-Format: `ST_TileName (A:pixel, ZoomLevel:int)`
-
-Since: `v1.0.0`
-
-Spark SQL example:
-```SQL
-SELECT ST_TileName(pixels.px, 3)
-FROM pixels
-```
-
 ### ST_Colorize
 
 Introduction: Given the weight of a pixel, return the corresponding color. The weight can be the spatial aggregation of spatial objects or spatial observations such as temperature and humidity.
 
 !!!note
-	The color is encoded to an Integer type value in DataFrame. When you print it, it will show some nonsense values. You can just treat them as colors in GeoSparkViz.
+The color is encoded to an Integer type value in DataFrame. When you print it, it will show some nonsense values. You can just treat them as colors in GeoSparkViz.
 
 Format: `ST_Colorize (weight:Double, maxWeight:Double, mandatory color: string (Optional))`
 
@@ -104,6 +71,39 @@ Spark SQL example:
 ```SQL
 SELECT ST_EncodeImage(images.img)
 FROM images
+```
+
+### ST_Pixelize
+
+Introduction: Convert a geometry to an array of pixels given a resolution
+
+You should use it together with `Lateral View` and `Explode`
+
+Format: `ST_Pixelize (A:geometry, ResolutionX:int, ResolutionY:int, Boundary:geometry)`
+
+Since: `v1.0.0`
+
+Spark SQL example:
+```SQL
+SELECT ST_Pixelize(shape, 256, 256, (ST_Envelope_Aggr(shape) FROM pointtable))
+FROM polygondf
+```
+
+### ST_TileName
+
+Introduction: Return the map tile name for a given zoom level. Please refer to [OpenStreetMap ZoomLevel](http://wiki.openstreetmap.org/wiki/Zoom_levels) and [OpenStreetMap tile name](https://wiki.openstreetmap.org/wiki/Slippy_map_tilenames).
+
+!!!note
+	Tile name is formatted as a "Z-X-Y" string. Z is zoom level. X is tile coordinate on X axis. Y is tile coordinate on Y axis.
+
+Format: `ST_TileName (A:pixel, ZoomLevel:int)`
+
+Since: `v1.0.0`
+
+Spark SQL example:
+```SQL
+SELECT ST_TileName(pixels.px, 3)
+FROM pixels
 ```
 
 ## Aggregate functions


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read [Contributor Rules](https://sedona.apache.org/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/community/develop/)

## Is this PR related to a JIRA ticket?

- No, this is a documentation update. The PR name follows the format `[DOCS] my subject`.

## What changes were proposed in this PR?

Currenly, the items in the API reference seems to be ordered randomly,
and it makes difficult for users to find the function they need.
It is more user-friendly if they were arranged in alphabetical order.

## How was this patch tested?

Ran `mkdocs serve` locally and made sure that the API docs were fixed as expected.

## Did this PR include necessary documentation updates?

- Yes, I have updated the documentation update.
