### PR TITLE
[SEDONA-139] Fix wrong argument order in Flink unit tests

### DIFF
--- a/flink/src/test/java/org/apache/sedona/flink/AdapterTest.java
+++ b/flink/src/test/java/org/apache/sedona/flink/AdapterTest.java
@@ -48,10 +48,10 @@ public class AdapterTest extends TestBase
                         $(polygonColNames[0])).as(polygonColNames[0]),
                 $(polygonColNames[1]));
         Row result = last(geomTable);
-        assertEquals(result.toString(), data.get(data.size() - 1).toString());
+        assertEquals(data.get(data.size() - 1).toString(), result.toString());
         // GeomTable to GeomDS
         DataStream<Row> geomStream = tableEnv.toDataStream(geomTable);
-        assertEquals(geomStream.executeAndCollect(1).get(0).toString(), data.get(0).toString());
+        assertEquals(data.get(0).toString(), geomStream.executeAndCollect(1).get(0).toString());
         // GeomDS to GeomTable
         geomTable = tableEnv.fromDataStream(geomStream);
         result = last(geomTable);

--- a/flink/src/test/java/org/apache/sedona/flink/ConstructorTest.java
+++ b/flink/src/test/java/org/apache/sedona/flink/ConstructorTest.java
@@ -67,14 +67,14 @@ public class ConstructorTest extends TestBase{
 
         String expected = "POINT (1 2)";
 
-        assertEquals(result, expected);
+        assertEquals(expected, result);
     }
 
     @Test
     public void testPointFromText() {
         List<Row> data = createPointWKT(testDataSize);
         Row result = last(createPointTable(testDataSize));
-        assertEquals(result.toString(), data.get(data.size() - 1).toString());
+        assertEquals(data.get(data.size() - 1).toString(), result.toString());
     }
 
     @Test
@@ -86,7 +86,7 @@ public class ConstructorTest extends TestBase{
                         $(linestringColNames[1]));
         Row result = last(lineStringTable);
 
-        assertEquals(result.toString(), data.get(data.size() - 1).toString());
+        assertEquals(data.get(data.size() - 1).toString(), result.toString());
     }
 
     @Test
@@ -98,14 +98,14 @@ public class ConstructorTest extends TestBase{
                         $(linestringColNames[1]));
         Row result = last(lineStringTable);
 
-        assertEquals(result.toString(), data.get(data.size() - 1).toString());
+        assertEquals(data.get(data.size() - 1).toString(), result.toString());
     }
 
     @Test
     public void testPolygonFromText() {
         List<Row> data = createPolygonWKT(testDataSize);
         Row result = last(createPolygonTable(testDataSize));
-        assertEquals(result.toString(), data.get(data.size() - 1).toString());
+        assertEquals(data.get(data.size() - 1).toString(), result.toString());
     }
 
     @Test
@@ -116,7 +116,7 @@ public class ConstructorTest extends TestBase{
                 $(polygonColNames[0])).as(polygonColNames[0]),
                 $(polygonColNames[1]));
         Row result = last(geomTable);
-        assertEquals(result.toString(), data.get(data.size() - 1).toString());
+        assertEquals(data.get(data.size() - 1).toString(), result.toString());
     }
 
     @Test
@@ -127,7 +127,7 @@ public class ConstructorTest extends TestBase{
                         $(polygonColNames[0])).as(polygonColNames[0]),
                 $(polygonColNames[1]));
         Row result = last(geomTable);
-        assertEquals(result.toString(), data.get(data.size() - 1).toString());
+        assertEquals(data.get(data.size() - 1).toString(), result.toString());
     }
 
     @Test
@@ -144,10 +144,10 @@ public class ConstructorTest extends TestBase{
         coordinates[4] = coordinates[0];
         GeometryFactory geometryFactory = new GeometryFactory();
         Geometry geom = geometryFactory.createPolygon(coordinates);
-        assertEquals(geom.toString(), last(tableEnv.sqlQuery("SELECT ST_PolygonFromEnvelope(1, 100, 2, 200)"))
-                .getField(0).toString());
-        assertEquals(geom.toString(), last(tableEnv.sqlQuery("SELECT ST_PolygonFromEnvelope(1.0, 100.0, 2.0, 200.0)"))
-                .getField(0).toString());
+        assertEquals(last(tableEnv.sqlQuery("SELECT ST_PolygonFromEnvelope(1, 100, 2, 200)"))
+                .getField(0).toString(), geom.toString());
+        assertEquals(last(tableEnv.sqlQuery("SELECT ST_PolygonFromEnvelope(1.0, 100.0, 2.0, 200.0)"))
+                .getField(0).toString(), geom.toString());
 
     }
 
@@ -167,7 +167,7 @@ public class ConstructorTest extends TestBase{
                 .getFieldAs(0);
         String expectedGeom = reader.read(expectedGeoJSON).toText();
 
-        assertEquals(result, expectedGeom);
+        assertEquals(expectedGeom, result);
     }
 
     @Test
@@ -191,7 +191,7 @@ public class ConstructorTest extends TestBase{
 
         String expectedGeom = "LINESTRING (-2.1047439575195312 -0.354827880859375, -1.49606454372406 -0.6676061153411865)";
 
-        assertEquals(result, expectedGeom);
+        assertEquals(expectedGeom, result);
 
        }
 
@@ -211,7 +211,7 @@ public class ConstructorTest extends TestBase{
                         .toString();
         String expectedGeom = "POLYGON ((-180 -39.375, -180 -33.75, -168.75 -33.75, -168.75 -39.375, -180 -39.375))";
 
-        assertEquals(result, expectedGeom);
+        assertEquals(expectedGeom, result);
     }
 
     @Test
@@ -229,6 +229,6 @@ public class ConstructorTest extends TestBase{
                 .toString();
         String expectedGeom = "POLYGON ((-178.4168529510498 -37.69778251647949, -178.4168529510498 -37.697739601135254, -178.41681003570557 -37.697739601135254, -178.41681003570557 -37.69778251647949, -178.4168529510498 -37.69778251647949))";
 
-        assertEquals(result, expectedGeom);
+        assertEquals(expectedGeom, result);
     }
 }

--- a/flink/src/test/java/org/apache/sedona/flink/FunctionTest.java
+++ b/flink/src/test/java/org/apache/sedona/flink/FunctionTest.java
@@ -67,7 +67,7 @@ public class FunctionTest extends TestBase{
     public void testYMax() {
         Table polygonTable = createPolygonTable(1);
         Table ResultTable = polygonTable.select(call(Functions.ST_YMax.class.getSimpleName(), $(polygonColNames[0])));
-        assert(first(ResultTable).getField(0)!=null);
+        assertNotNull(first(ResultTable).getField(0));
         double result = (double) first(ResultTable).getField(0);
         assertEquals(0.5, result,0);
     }
@@ -76,7 +76,7 @@ public class FunctionTest extends TestBase{
     public void testYMin() {
         Table polygonTable = createPolygonTable(1);
         Table ResultTable = polygonTable.select(call(Functions.ST_YMin.class.getSimpleName(), $(polygonColNames[0])));
-        assert(first(ResultTable).getField(0)!=null);
+        assertNotNull(first(ResultTable).getField(0));
         double result = (double) first(ResultTable).getField(0);
         assertEquals(-0.5, result, 0);
     }
@@ -114,8 +114,8 @@ public class FunctionTest extends TestBase{
         Table linestringTable = polygonTable.select(call(Functions.ST_ExteriorRing.class.getSimpleName(), $(polygonColNames[0])));
         Table pointTable = linestringTable.select(call(Functions.ST_PointN.class.getSimpleName(), $("_c0"), n));
         Point point = (Point) first(pointTable).getField(0);
-        assert point != null;
-        Assert.assertEquals("POINT (-0.5 -0.5)", point.toString());
+        assertNotNull(point);
+        assertEquals("POINT (-0.5 -0.5)", point.toString());
     }
 
     @Test
@@ -125,8 +125,8 @@ public class FunctionTest extends TestBase{
         Table linestringTable = polygonTable.select(call(Functions.ST_ExteriorRing.class.getSimpleName(), $(polygonColNames[0])));
         Table pointTable = linestringTable.select(call(Functions.ST_PointN.class.getSimpleName(), $("_c0"), n));
         Point point = (Point) first(pointTable).getField(0);
-        assert point != null;
-        Assert.assertEquals("POINT (0.5 0.5)", point.toString());
+        assertNotNull(point);
+        assertEquals("POINT (0.5 0.5)", point.toString());
     }
 
     @Test
@@ -134,7 +134,7 @@ public class FunctionTest extends TestBase{
         Table polygonTable = createPolygonTable(1);
         Table linearRingTable = polygonTable.select(call(Functions.ST_ExteriorRing.class.getSimpleName(), $(polygonColNames[0])));
         LinearRing linearRing = (LinearRing) first(linearRingTable).getField(0);
-        assert linearRing != null;
+        assertNotNull(linearRing);
         Assert.assertEquals("LINEARRING (-0.5 -0.5, -0.5 0.5, 0.5 0.5, 0.5 -0.5, -0.5 -0.5)", linearRing.toString());
     }
 

--- a/flink/src/test/java/org/apache/sedona/flink/PredicateTest.java
+++ b/flink/src/test/java/org/apache/sedona/flink/PredicateTest.java
@@ -31,7 +31,7 @@ public class PredicateTest extends TestBase{
         String polygon = createPolygonWKT(testDataSize).get(0).getField(0).toString();
         String expr = "ST_Intersects(ST_GeomFromWkt('" + polygon + "'), geom_point)";
         Table result = pointTable.filter(expr);
-        assertEquals(count(result), 1);
+        assertEquals(1, count(result));
     }
 
     @Test
@@ -40,6 +40,6 @@ public class PredicateTest extends TestBase{
         String polygon = createPolygonWKT(testDataSize).get(0).getField(0).toString();
         String expr = "ST_Disjoint(ST_GeomFromWkt('" + polygon + "'), geom_point)";
         Table result = pointTable.filter(expr);
-        assertEquals(count(result), 999);
+        assertEquals(999, count(result));
     }
 }


### PR DESCRIPTION

## Did you read the Contributor Guide?

- Yes, I have read [Contributor Rules](https://sedona.apache.org/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/community/develop/)

## Is this PR related to a JIRA ticket?

- Yes, the URL of the assoicated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-139. The PR name follows the format `[SEDONA-XXX] my subject`.

## What changes were proposed in this PR?

- This PR fixes the argument order passed to JUnit's assert methods so that developers doesn't get confused.

## How was this patch tested?

- Ran `mvn test -pl flink` locally and ensured all tests passed.

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the docs.
