### PR TITLE
[SEDONA-143] Add missing unit tests for the Flink predicates

### DIFF
--- a/flink/src/test/java/org/apache/sedona/flink/PredicateTest.java
+++ b/flink/src/test/java/org/apache/sedona/flink/PredicateTest.java
@@ -42,4 +42,22 @@ public class PredicateTest extends TestBase{
         Table result = pointTable.filter(expr);
         assertEquals(999, count(result));
     }
+
+    @Test
+    public void testContains() {
+        Table pointTable = createPointTable(testDataSize);
+        String polygon = createPolygonWKT(testDataSize).get(0).getField(0).toString();
+        String expr = "ST_Contains(ST_GeomFromWkt('" + polygon + "'), geom_point)";
+        Table result = pointTable.filter(expr);
+        assertEquals(1, count(result));
+    }
+
+    @Test
+    public void testOrderingEquals() {
+        Table lineStringTable = createLineStringTable(testDataSize);
+        String lineString = createLineStringWKT(testDataSize).get(0).getField(0).toString();
+        String expr = "ST_OrderingEquals(ST_GeomFromWkt('" + lineString + "'), geom_linestring)";
+        Table result = lineStringTable.filter(expr);
+        assertEquals(1, count(result));
+    }
 }

--- a/flink/src/test/java/org/apache/sedona/flink/TestBase.java
+++ b/flink/src/test/java/org/apache/sedona/flink/TestBase.java
@@ -247,6 +247,13 @@ public class TestBase {
                         $(pointColNames[1]));
     }
 
+    static Table createLineStringTable(int size) {
+        return createLineStringTextTable(size)
+                .select(call(Constructors.ST_LineStringFromText.class.getSimpleName(),
+                        $(linestringColNames[0])).as(linestringColNames[0]),
+                        $(linestringColNames[1]));
+    }
+
     Table createPolygonTable(int size) {
         return createPolygonTextTable(size)
                 .select(call(Constructors.ST_PolygonFromText.class.getSimpleName(),


### PR DESCRIPTION

## Did you read the Contributor Guide?

- Yes, I have read [Contributor Rules](https://sedona.apache.org/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/community/develop/)

## Is this PR related to a JIRA ticket?

- Yes, the URL of the assoicated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-143. The PR name follows the format `[SEDONA-XXX] my subject`.

## What changes were proposed in this PR?

Currently, ST_Contains and ST_OrderingEquals for Flink don't have their unit test. This PR adds them.

## How was this patch tested?

Ran `mvn test -pl flink` locally.

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the docs.
