### PR TITLE
[SEDONA-145] Fix ST_AsEWKT to reserve the Z coordinate

### DIFF
--- a/common/src/main/java/org/apache/sedona/common/utils/GeomUtils.java
+++ b/common/src/main/java/org/apache/sedona/common/utils/GeomUtils.java
@@ -136,7 +136,7 @@ public class GeomUtils {
             sridString = "SRID=" + String.valueOf(srid) + ";";
         }
 
-        return sridString + new WKTWriter().write(geometry);
+        return sridString + new WKTWriter(GeomUtils.getDimension(geometry)).write(geometry);
     }
 
     public static Geometry get2dGeom(Geometry geom) {
@@ -185,6 +185,10 @@ public class GeomUtils {
             outputGeom.setSRID(srid);
         }
         return outputGeom;
+    }
+
+    public static int getDimension(Geometry geometry) {
+        return geometry.getCoordinate() != null && !java.lang.Double.isNaN(geometry.getCoordinate().getZ()) ? 3 : 2;
     }
 
     private static Map<Polygon, Polygon> findFaceHoles(List<Polygon> faces) {

--- a/python/tests/sql/test_function.py
+++ b/python/tests/sql/test_function.py
@@ -947,14 +947,11 @@ class TestPredicateJoin(TestBase):
             pointOnSurface = self.spark.sql("select ST_AsText(ST_PointOnSurface(ST_GeomFromText({})))".format(input_geom))
             assert pointOnSurface.take(1)[0][0] == expected_geom
 
-        '''
-        ST_AsEWKT Has not been implemented yet
-        tests2 = { "'LINESTRING(0 5 1, 0 0 1, 0 10 2)'":"POINT(0 0 1)" }
+        tests2 = { "'LINESTRING(0 5 1, 0 0 1, 0 10 2)'":"POINT Z(0 0 1)" }
 
         for input_geom, expected_geom in tests2.items():
-            pointOnSurface = self.spark.sql("select ST_AsEWKT(ST_PointOnSurface(ST_GeomFromEWKT({})))".format(input_geom))
+            pointOnSurface = self.spark.sql("select ST_AsEWKT(ST_PointOnSurface(ST_GeomFromWKT({})))".format(input_geom))
             assert pointOnSurface.take(1)[0][0] == expected_geom
-        '''
 
     def test_st_pointn(self):
         linestring = "'LINESTRING(0 0, 1 2, 2 4, 3 6)'"

--- a/sql/src/main/scala/org/apache/sedona/sql/utils/GeometrySerializer.scala
+++ b/sql/src/main/scala/org/apache/sedona/sql/utils/GeometrySerializer.scala
@@ -18,6 +18,7 @@
  */
 package org.apache.sedona.sql.utils
 
+import org.apache.sedona.common.utils.GeomUtils;
 import org.apache.spark.sql.catalyst.util.ArrayData
 import org.locationtech.jts.geom.Geometry
 import org.locationtech.jts.io.{WKBReader, WKBWriter}
@@ -34,7 +35,7 @@ object GeometrySerializer {
     * @return Array of bites represents this geometry
     */
   def serialize(geometry: Geometry): Array[Byte] = {
-    val writer = new WKBWriter(getDimension(geometry), 2, true)
+    val writer = new WKBWriter(GeomUtils.getDimension(geometry), 2, true)
     writer.write(geometry)
   }
 
@@ -47,9 +48,5 @@ object GeometrySerializer {
   def deserialize(values: ArrayData): Geometry = {
     val reader = new WKBReader()
     reader.read(values.toByteArray())
-  }
-
-  def getDimension(geometry: Geometry): Int = {
-    if (geometry.getCoordinate != null && !java.lang.Double.isNaN(geometry.getCoordinate.getZ)) 3 else 2
   }
 }

--- a/sql/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/Functions.scala
+++ b/sql/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/Functions.scala
@@ -19,6 +19,7 @@
 package org.apache.spark.sql.sedona_sql.expressions
 
 import org.apache.sedona.common.Functions
+import org.apache.sedona.common.utils.GeomUtils
 import org.apache.sedona.core.geometryObjects.Circle
 import org.apache.sedona.sql.utils.GeometrySerializer
 import org.apache.spark.internal.Logging
@@ -477,7 +478,7 @@ case class ST_AsText(inputExpressions: Seq[Expression])
   assert(inputExpressions.length == 1)
 
   override protected def nullSafeEval(geometry: Geometry): Any = {
-    val writer = new WKTWriter(GeometrySerializer.getDimension(geometry))
+    val writer = new WKTWriter(GeomUtils.getDimension(geometry))
     UTF8String.fromString(writer.write(geometry))
   }
 

--- a/sql/src/test/scala/org/apache/sedona/sql/functionTestScala.scala
+++ b/sql/src/test/scala/org/apache/sedona/sql/functionTestScala.scala
@@ -1291,25 +1291,22 @@ class functionTestScala extends TestBaseScala with Matchers with GeometrySample 
         -> "POINT Z(0 0 1)"
     )
 
-        for((inputGeom, expectedGeom) <- geomTestCases1) {
-      var df = sparkSession.sql(s"select ST_AsText(ST_PointOnSurface(ST_GeomFromText($inputGeom)))")
-      var result = df.collect()
+    for((inputGeom, expectedGeom) <- geomTestCases1) {
+      val df = sparkSession.sql(s"select ST_AsText(ST_PointOnSurface(ST_GeomFromText($inputGeom)))")
+      val result = df.collect()
       assert(result.head.get(0).asInstanceOf[String]==expectedGeom)
     }
-
-    /* ST_AsEWKT Has not been implemented yet
 
     val geomTestCases2 = Map(
       "'LINESTRING(0 5 1, 0 0 1, 0 10 2)'"
-        -> "POINT (0 0 1)"
+        -> "POINT Z(0 0 1)"
     )
 
     for((inputGeom, expectedGeom) <- geomTestCases2) {
-      var df = sparkSession.sql(s"select ST_AsEWKT(ST_PointOnSurface(ST_GeomFromEWKT($inputGeom)))")
-      var result = df.collect()
+      val df = sparkSession.sql(s"select ST_AsEWKT(ST_PointOnSurface(ST_GeomFromWKT($inputGeom)))")
+      val result = df.collect()
       assert(result.head.get(0).asInstanceOf[String]==expectedGeom)
     }
-    */
   }
 
   it ("Should pass ST_Reverse") {


### PR DESCRIPTION

## Did you read the Contributor Guide?

- Yes, I have read [Contributor Rules](https://sedona.apache.org/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/community/develop/)

## Is this PR related to a JIRA ticket?

- Yes, the URL of the assoicated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-145. The PR name follows the format `[SEDONA-XXX] my subject`.

## What changes were proposed in this PR?

- This PR fixes ST_AsEWKT to reserve the Z coordinate.

## How was this patch tested?

- Ran `mvn clean install -Dgeotools` locally
- Ran `pipenv run pytest tests/sql/test_function.py` locally with the artifact above

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the docs.
