### PR TITLE
[DOCS] Document SQL functions not in the API reference

### DIFF
--- a/docs/api/sql/Constructor.md
+++ b/docs/api/sql/Constructor.md
@@ -90,6 +90,20 @@ polygonDf.show()
 !!!warning
 	The way that SedonaSQL reads GeoJSON is different from that in SparkSQL
 
+## ST_GeomFromText
+
+Introduction: Construct a Geometry from Wkt. Alias of [ST_GeomFromWKT](#ST_GeomFromWKT)
+
+Format:
+`ST_GeomFromText (Wkt:string)`
+
+Since: `v1.0.0`
+
+Spark SQL example:
+```SQL
+SELECT ST_GeomFromText('POINT(40.7128 -74.0060)') AS geometry
+```
+
 ## ST_GeomFromWKB
 
 Introduction: Construct a Geometry from WKB string or Binary

--- a/docs/api/sql/Function.md
+++ b/docs/api/sql/Function.md
@@ -646,6 +646,28 @@ SELECT ST_Length(polygondf.countyshape)
 FROM polygondf
 ```
 
+## ST_LineInterpolatePoint
+
+Introduction: Returns a point interpolated along a line. First argument must be a LINESTRING. Second argument is a Double between 0 and 1 representing fraction of total linestring length the point has to be located.
+
+Format: `ST_LineInterpolatePoint (geom: geometry, fraction: Double)`
+
+Since: `v1.0.1`
+
+Spark SQL example:
+```SQL
+SELECT ST_LineInterpolatePoint(ST_GeomFromWKT('LINESTRING(25 50, 100 125, 150 190)'), 0.2) as Interpolated
+```
+
+Output:
+```
++-----------------------------------------+
+|Interpolated                             |
++-----------------------------------------+
+|POINT (51.5974135047432 76.5974135047432)|
++-----------------------------------------+
+```
+
 ## ST_LineMerge
 
 Introduction: Returns a LineString formed by sewing together the constituent line work of a MULTILINESTRING.
@@ -660,6 +682,28 @@ Since: `v1.0.0`
 ```SQL
 SELECT ST_LineMerge(geometry)
 FROM df
+```
+
+## ST_LineSubstring
+
+Introduction: Return a linestring being a substring of the input one starting and ending at the given fractions of total 2d length. Second and third arguments are Double values between 0 and 1. This only works with LINESTRINGs.
+
+Format: `ST_LineSubstring (geom: geometry, startfraction: Double, endfraction: Double)`
+
+Since: `v1.0.1`
+
+Spark SQL example:
+```SQL
+SELECT ST_LineSubstring(ST_GeomFromWKT('LINESTRING(25 50, 100 125, 150 190)'), 0.333, 0.666) as Substring
+```
+
+Output:
+```
++------------------------------------------------------------------------------------------------+
+|Substring                                                                                       |
++------------------------------------------------------------------------------------------------+
+|LINESTRING (69.28469348539744 94.28469348539744, 100 125, 111.70035626068274 140.21046313888758)|
++------------------------------------------------------------------------------------------------+
 ```
 
 ## ST_MakePolygon


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read [Contributor Rules](https://sedona.apache.org/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/community/develop/)

## Is this PR related to a JIRA ticket?

- No, this is a documentation update. The PR name follows the format `[DOCS] my subject`.

## What changes were proposed in this PR?

This PR adds the following missing functions to the Spark SQL reference.

* ST_GeomFromText
* ST_LineInterpolatePoint
* ST_LineSubstring

## How was this patch tested?

- Ran `mkdocs serve` locally

## Did this PR include necessary documentation updates?

- Yes, I have updated the documentation update.
