### PR TITLE
[SEDONA-153] Add None guards to GeometryType

### DIFF
--- a/python/sedona/sql/types.py
+++ b/python/sedona/sql/types.py
@@ -28,10 +28,16 @@ class GeometryType(UserDefinedType):
         return ArrayType(ByteType(), containsNull=False)
 
     def fromInternal(self, obj):
-        return self.deserialize(obj)
+        deserialized_obj = None
+        if obj is not None:
+            deserialized_obj = self.deserialize(obj)
+        return deserialized_obj
 
     def toInternal(self, obj):
-        return [el - 256 if el >= 128 else el for el in self.serialize(obj)]
+        serialized_obj = None
+        if obj is not None:
+            serialized_obj = [el - 256 if el >= 128 else el for el in self.serialize(obj)]
+        return serialized_obj
 
     def serialize(self, obj):
         return dumps(obj)

--- a/python/tests/serialization/test_deserializers.py
+++ b/python/tests/serialization/test_deserializers.py
@@ -116,3 +116,7 @@ class TestGeometryConvert(TestBase):
 
         gdf = counties_geom.toPandas()
         print(gpd.GeoDataFrame(gdf, geometry="geometry"))
+
+    def test_null_deserializer(self):
+        result = self.spark.sql("select st_geomfromwkt(null)").collect()[0][0]
+        assert result is None

--- a/python/tests/serialization/test_serializers.py
+++ b/python/tests/serialization/test_serializers.py
@@ -179,3 +179,23 @@ class TestsSerializers(TestBase):
         ).createOrReplaceTempView("polygon")
         length = self.spark.sql("select st_area(geom) from polygon").collect()[0][0]
         assert length == 4.75
+
+    def test_null_serializer(self):
+        data = [
+            [1, None]
+
+        ]
+
+        schema = t.StructType(
+            [
+                t.StructField("id", IntegerType(), True),
+                t.StructField("geom", GeometryType(), True),
+            ]
+        )
+        self.spark.createDataFrame(
+            data,
+            schema
+        ).createOrReplaceTempView("points")
+
+        count = self.spark.sql("select count(*) from points").collect()[0][0]
+        assert count == 1


### PR DESCRIPTION

## Did you read the Contributor Guide?

- Yes, I have read [Contributor Rules](https://sedona.apache.org/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/community/develop/)

## Is this PR related to a JIRA ticket?

- Yes, the URL of the associated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-153. The PR name follows the format `[SEDONA-XXX] my subject`.

## What changes were proposed in this PR?

- Added guards to the python methods `GeometryType.toInternal` and `GeometryType.fromInternal`. This allows for null geometry to be passed between python and the JVM.

## How was this patch tested?

- Added two new unit tests: `test_null_deserializer` in test_deserializers.py and `test_null_serializer` in test_serializers.py. Both of these tests fail on the current release of Sedona and now pass with this PR.

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the docs.
