### PR TITLE
[SEDONA-159] Add Nth accessor functions to the Flink API

### DIFF
--- a/common/src/main/java/org/apache/sedona/common/Functions.java
+++ b/common/src/main/java/org/apache/sedona/common/Functions.java
@@ -157,6 +157,23 @@ public class Functions {
         return geometry.reverse();
     }
 
+    public static Geometry geometryN(Geometry geometry, int n) {
+        if (n < geometry.getNumGeometries()) {
+            return geometry.getGeometryN(n);
+        }
+        return null;
+    }
+
+    public static Geometry interiorRingN(Geometry geometry, int n) {
+        if (geometry instanceof Polygon) {
+            Polygon polygon = (Polygon) geometry;
+            if (n < polygon.getNumInteriorRing()) {
+                return polygon.getInteriorRingN(n);
+            }
+        }
+        return null;
+    }
+
     public static Geometry pointN(Geometry geometry, int n) {
         if(!(geometry instanceof LineString)) {
             return null;

--- a/docs/api/flink/Function.md
+++ b/docs/api/flink/Function.md
@@ -281,6 +281,36 @@ Result:
 +-----------------------------+
 ```
 
+## ST_GeometryN
+
+Introduction: Return the 0-based Nth geometry if the geometry is a GEOMETRYCOLLECTION, (MULTI)POINT, (MULTI)LINESTRING, MULTICURVE or (MULTI)POLYGON. Otherwise, return null
+
+Format: `ST_GeometryN(geom: geometry, n: Int)`
+
+Since: `v1.3.0`
+
+Example:
+```SQL
+SELECT ST_GeometryN(ST_GeomFromText('MULTIPOINT((1 2), (3 4), (5 6), (8 9))'), 1)
+```
+
+Output: `POINT (3 4)`
+
+## ST_InteriorRingN
+
+Introduction: Returns the Nth interior linestring ring of the polygon geometry. Returns NULL if the geometry is not a polygon or the given N is out of range
+
+Format: `ST_InteriorRingN(geom: geometry, n: Int)`
+
+Since: `v1.3.0`
+
+Example:
+```SQL
+SELECT ST_InteriorRingN(ST_GeomFromText('POLYGON((0 0, 0 5, 5 5, 5 0, 0 0), (1 1, 2 1, 2 2, 1 2, 1 1), (1 3, 2 3, 2 4, 1 4, 1 3), (3 3, 4 3, 4 4, 3 4, 3 3))'), 0)
+```
+
+Output: `LINEARRING (1 1, 2 1, 2 2, 1 2, 1 1)`
+
 ## ST_IsClosed
 
 Introduction: RETURNS true if the LINESTRING start and end point are the same.

--- a/flink/src/main/java/org/apache/sedona/flink/Catalog.java
+++ b/flink/src/main/java/org/apache/sedona/flink/Catalog.java
@@ -45,6 +45,8 @@ public class Catalog {
                 new Functions.ST_GeoHash(),
                 new Functions.ST_PointOnSurface(),
                 new Functions.ST_Reverse(),
+                new Functions.ST_GeometryN(),
+                new Functions.ST_InteriorRingN(),
                 new Functions.ST_PointN(),
                 new Functions.ST_ExteriorRing(),
                 new Functions.ST_AsEWKT(),

--- a/flink/src/main/java/org/apache/sedona/flink/expressions/Functions.java
+++ b/flink/src/main/java/org/apache/sedona/flink/expressions/Functions.java
@@ -133,6 +133,22 @@ public class Functions {
         }
     }
 
+    public static class ST_GeometryN extends ScalarFunction {
+        @DataTypeHint(value = "RAW", bridgedTo = org.locationtech.jts.geom.Geometry.class)
+        public Geometry eval(@DataTypeHint(value = "RAW", bridgedTo = org.locationtech.jts.geom.Geometry.class) Object o, int n) {
+            Geometry geom = (Geometry) o;
+            return org.apache.sedona.common.Functions.geometryN(geom, n);
+        }
+    }
+
+    public static class ST_InteriorRingN extends ScalarFunction {
+        @DataTypeHint(value = "RAW", bridgedTo = org.locationtech.jts.geom.Geometry.class)
+        public Geometry eval(@DataTypeHint(value = "RAW", bridgedTo = org.locationtech.jts.geom.Geometry.class) Object o, int n) {
+            Geometry geom = (Geometry) o;
+            return org.apache.sedona.common.Functions.interiorRingN(geom, n);
+        }
+    }
+
     public static class ST_PointN extends ScalarFunction {
         @DataTypeHint(value = "RAW", bridgedTo = org.locationtech.jts.geom.Geometry.class)
         public Geometry eval(@DataTypeHint(value = "RAW", bridgedTo = org.locationtech.jts.geom.Geometry.class) Object o, int n) {

--- a/flink/src/test/java/org/apache/sedona/flink/FunctionTest.java
+++ b/flink/src/test/java/org/apache/sedona/flink/FunctionTest.java
@@ -145,6 +145,22 @@ public class FunctionTest extends TestBase{
     }
 
     @Test
+    public void testGeometryN() {
+        Table collectionTable = tableEnv.sqlQuery("SELECT ST_GeomFromWKT('GEOMETRYCOLLECTION(POINT(10 10), POINT(30 30), LINESTRING(15 15, 20 20))') AS collection");
+        Table resultTable = collectionTable.select(call(Functions.ST_GeometryN.class.getSimpleName(), $("collection"), 1));
+        Point point = (Point) first(resultTable).getField(0);
+        assertEquals("POINT (30 30)", point.toString());
+    }
+
+    @Test
+    public void testInteriorRingN() {
+        Table polygonTable = tableEnv.sqlQuery("SELECT ST_GeomFromText('POLYGON((7 9,8 7,11 6,15 8,16 6,17 7,17 10,18 12,17 14,15 15,11 15,10 13,9 12,7 9),(9 9,10 10,11 11,11 10,10 8,9 9),(12 14,15 14,13 11,12 14))') AS polygon");
+        Table resultTable = polygonTable.select(call(Functions.ST_InteriorRingN.class.getSimpleName(), $("polygon"), 1));
+        LinearRing linearRing = (LinearRing) first(resultTable).getField(0);
+        assertEquals("LINEARRING (12 14, 15 14, 13 11, 12 14)", linearRing.toString());
+    }
+
+    @Test
     public void testPointN_positiveN() {
         int n = 1;
         Table polygonTable = createPolygonTable(1);


### PR DESCRIPTION

## Did you read the Contributor Guide?

- Yes, I have read [Contributor Rules](https://sedona.apache.org/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/community/develop/)

## Is this PR related to a JIRA ticket?

- Yes, the URL of the assoicated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-159. The PR name follows the format `[SEDONA-XXX] my subject`.

## What changes were proposed in this PR?

This PR adds ST_GeometryN and ST_InteriorRingN to the Flink API.

## How was this patch tested?

- Ran `mvn clean install` locally.
- Ran `mkdocs serve` and checked the generated documents.

## Did this PR include necessary documentation updates?

- Yes, I am adding a new API. I am using the [1.3.0](https://github.com/apache/incubator-sedona/blob/master/pom.xml#L29) in since `vX.Y.Z` format.
