### PR TITLE
[SEDONA-160] Fix geoparquetIOTests.scala to cleanup after test

### DIFF
--- a/sql/src/test/scala/org/apache/sedona/sql/geoparquetIOTests.scala
+++ b/sql/src/test/scala/org/apache/sedona/sql/geoparquetIOTests.scala
@@ -1,14 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.sedona.sql
 
+import org.apache.commons.io.FileUtils
 import org.apache.spark.sql.SaveMode
 import org.locationtech.jts.geom.Geometry
-import org.scalatest.BeforeAndAfter
+import org.scalatest.BeforeAndAfterAll
 
-class geoparquetIOTests extends TestBaseScala  with BeforeAndAfter{
-  var geoparquetdatalocation1: String = resourceFolder + "geoparquet/example1.parquet"
-  var geoparquetdatalocation2: String = resourceFolder + "geoparquet/example2.parquet"
-  var geoparquetdatalocation3: String = resourceFolder + "geoparquet/example3.parquet"
-  var geoparquetoutputlocation: String = resourceFolder + "geoparquet/geoparquet_output/"
+import java.io.File
+
+class geoparquetIOTests extends TestBaseScala with BeforeAndAfterAll {
+  val geoparquetdatalocation1: String = resourceFolder + "geoparquet/example1.parquet"
+  val geoparquetdatalocation2: String = resourceFolder + "geoparquet/example2.parquet"
+  val geoparquetdatalocation3: String = resourceFolder + "geoparquet/example3.parquet"
+  val geoparquetoutputlocation: String = resourceFolder + "geoparquet/geoparquet_output/"
+
+  override def afterAll(): Unit = FileUtils.deleteDirectory(new File(geoparquetoutputlocation))
 
   describe("GeoParquet IO tests"){
     it("GEOPARQUET Test example1 i.e. naturalearth_lowers dataset's Read and Write"){


### PR DESCRIPTION

## Did you read the Contributor Guide?

- Yes, I have read [Contributor Rules](https://sedona.apache.org/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/community/develop/)

## Is this PR related to a JIRA ticket?

- Yes, the URL of the assoicated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-160. The PR name follows the format `[SEDONA-XXX] my subject`.

## What changes were proposed in this PR?

- This PR fixes geoparquetIOTests.scala to remove its output files after running tests.

## How was this patch tested?

- Ran `mvn clean test -pl sql -am` and confirmed that no output files were left after tests

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the docs.
