### PR TITLE
[SEDONA-169] Fix ST_RemovePoint in accordance with the API document

### DIFF
--- a/sql/src/test/scala/org/apache/sedona/sql/functionTestScala.scala
+++ b/sql/src/test/scala/org/apache/sedona/sql/functionTestScala.scala
@@ -979,6 +979,7 @@ class functionTestScala extends TestBaseScala with Matchers with GeometrySample 
   }
 
   it("Should correctly remove using ST_RemovePoint") {
+    calculateStRemovePointOption("Linestring(0 0, 1 1, 1 0, 0 0)") shouldBe Some("LINESTRING (0 0, 1 1, 1 0)")
     calculateStRemovePointOption("Linestring(0 0, 1 1, 1 0, 0 0)", 0) shouldBe Some("LINESTRING (1 1, 1 0, 0 0)")
     calculateStRemovePointOption("Linestring(0 0, 1 1)", 0) shouldBe None
     calculateStRemovePointOption("Linestring(0 0, 1 1, 1 0, 0 0)", 1) shouldBe Some("LINESTRING (0 0, 1 0, 0 0)")
@@ -1134,6 +1135,14 @@ class functionTestScala extends TestBaseScala with Matchers with GeometrySample 
 
   private def wktToDf(wkt: String): DataFrame =
     Seq(Tuple1(wktReader.read(wkt))).toDF("geom")
+
+  private def calculateStRemovePointOption(wkt: String): Option[String] =
+    calculateStRemovePoint(wkt).headOption
+
+  private def calculateStRemovePoint(wkt: String): Array[String] =
+    wktToDf(wkt).selectExpr(s"ST_RemovePoint(geom) as geom")
+      .filter("geom is not null")
+      .selectExpr("ST_AsText(geom)").as[String].collect()
 
   private def calculateStRemovePointOption(wkt: String, index: Int): Option[String] =
     calculateStRemovePoint(wkt, index).headOption


### PR DESCRIPTION

## Did you read the Contributor Guide?

- Yes, I have read [Contributor Rules](https://sedona.apache.org/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/community/develop/)

## Is this PR related to a JIRA ticket?

- Yes, the URL of the assoicated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-169. The PR name follows the format `[SEDONA-XXX] my subject`.

## What changes were proposed in this PR?

This PR fixes ST_RemovePoint to work without the second parameter, in accordance with its API document.

## How was this patch tested?

Ran `mvn clean install` locally.

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the docs.
