### PR TITLE
[SEDONA-176] Make ST_Contains conform with OGC standard, and add ST_Covers and ST_CoveredBy functions.

### DIFF
--- a/docs/api/flink/Predicate.md
+++ b/docs/api/flink/Predicate.md
@@ -43,6 +43,21 @@ FROM pointdf
 WHERE ST_Intersects(ST_PolygonFromEnvelope(1.0,100.0,1000.0,1100.0), pointdf.arealandmark)
 ```
 
+## ST_Within
+
+Introduction: Return true if A is within B
+
+Format: `ST_Within (A:geometry, B:geometry)`
+
+Since: `v1.3.0`
+
+SQL example:
+```SQL
+SELECT * 
+FROM pointdf 
+WHERE ST_Within(pointdf.arealandmark, ST_PolygonFromEnvelope(1.0,100.0,1000.0,1100.0))
+```
+
 ## ST_OrderingEquals
 Introduction: Returns true if the geometries are equal and the coordinates are in the same order
 
@@ -63,3 +78,33 @@ SELECT ST_OrderingEquals(ST_GeomFromWKT('POLYGON((2 0, 0 2, -2 0, 2 0))'), ST_Ge
 ```
 
 Output: `false`
+
+## ST_Covers
+
+Introduction: Return true if A covers B
+
+Format: `ST_Covers (A:geometry, B:geometry)`
+
+Since: `v1.3.0`
+
+SQL example:
+```SQL
+SELECT * 
+FROM pointdf 
+WHERE ST_Covers(ST_PolygonFromEnvelope(1.0,100.0,1000.0,1100.0), pointdf.arealandmark)
+```
+
+## ST_CoveredBy
+
+Introduction: Return true if A is covered by B
+
+Format: `ST_CoveredBy (A:geometry, B:geometry)`
+
+Since: `v1.3.0`
+
+SQL example:
+```SQL
+SELECT * 
+FROM pointdf 
+WHERE ST_CoveredBy(pointdf.arealandmark, ST_PolygonFromEnvelope(1.0,100.0,1000.0,1100.0))
+```

--- a/docs/api/sql/Predicate.md
+++ b/docs/api/sql/Predicate.md
@@ -137,3 +137,33 @@ SELECT *
 FROM pointdf 
 WHERE ST_Within(pointdf.arealandmark, ST_PolygonFromEnvelope(1.0,100.0,1000.0,1100.0))
 ```
+
+## ST_Covers
+
+Introduction: Return true if A covers B
+
+Format: `ST_Covers (A:geometry, B:geometry)`
+
+Since: `v1.3.0`
+
+Spark SQL example:
+```SQL
+SELECT * 
+FROM pointdf 
+WHERE ST_Covers(ST_PolygonFromEnvelope(1.0,100.0,1000.0,1100.0), pointdf.arealandmark)
+```
+
+## ST_CoveredBy
+
+Introduction: Return true if A is covered by B
+
+Format: `ST_CoveredBy (A:geometry, B:geometry)`
+
+Since: `v1.3.0`
+
+Spark SQL example:
+```SQL
+SELECT * 
+FROM pointdf 
+WHERE ST_CoveredBy(pointdf.arealandmark, ST_PolygonFromEnvelope(1.0,100.0,1000.0,1100.0))
+```

--- a/flink/src/main/java/org/apache/sedona/flink/Catalog.java
+++ b/flink/src/main/java/org/apache/sedona/flink/Catalog.java
@@ -88,6 +88,9 @@ public class Catalog {
         return new UserDefinedFunction[]{
                 new Predicates.ST_Intersects(),
                 new Predicates.ST_Contains(),
+                new Predicates.ST_Within(),
+                new Predicates.ST_Covers(),
+                new Predicates.ST_CoveredBy(),
                 new Predicates.ST_Disjoint(),
                 new Predicates.ST_OrderingEquals(),
         };

--- a/flink/src/main/java/org/apache/sedona/flink/expressions/Predicates.java
+++ b/flink/src/main/java/org/apache/sedona/flink/expressions/Predicates.java
@@ -85,6 +85,86 @@ public class Predicates {
         public Boolean eval(@DataTypeHint(value = "RAW", bridgedTo = org.locationtech.jts.geom.Geometry.class) Object o1, @DataTypeHint(value = "RAW", bridgedTo = org.locationtech.jts.geom.Geometry.class) Object o2) {
             Geometry geom1 = (Geometry) o1;
             Geometry geom2 = (Geometry) o2;
+            return geom1.contains(geom2);
+        }
+
+        /**
+         * Check spatial relation with duplicates removal
+         * @param key
+         * @param o1
+         * @param o2
+         * @return
+         */
+        @DataTypeHint("Boolean")
+        public Boolean eval(@DataTypeHint("INT") Integer key, @DataTypeHint(value = "RAW", bridgedTo = org.locationtech.jts.geom.Geometry.class) Object o1, @DataTypeHint(value = "RAW", bridgedTo = org.locationtech.jts.geom.Geometry.class) Object o2) {
+            Objects.requireNonNull(grids, "This predicate has to be initialized by a partitioner.");
+            Geometry geom1 = (Geometry) o1;
+            Geometry geom2 = (Geometry) o2;
+            HalfOpenRectangle halfOpenRectangle = new HalfOpenRectangle(grids.get(key));
+            return JudgementHelper.match(geom1, geom2, halfOpenRectangle, false);
+        }
+    }
+
+    public static class ST_Within extends ScalarFunction {
+        private List<Envelope> grids;
+
+        /**
+         * Constructor for duplicate removal
+         */
+        public ST_Within(PartitioningUtils partitioner) {
+            grids = partitioner.fetchLeafZones();
+        }
+
+        /**
+         * Constructor for relation checking without duplicate removal
+         */
+        public ST_Within() {
+        }
+
+        @DataTypeHint("Boolean")
+        public Boolean eval(@DataTypeHint(value = "RAW", bridgedTo = org.locationtech.jts.geom.Geometry.class) Object o1, @DataTypeHint(value = "RAW", bridgedTo = org.locationtech.jts.geom.Geometry.class) Object o2) {
+            Geometry geom1 = (Geometry) o1;
+            Geometry geom2 = (Geometry) o2;
+            return geom1.within(geom2);
+        }
+
+        /**
+         * Check spatial relation with duplicates removal
+         * @param key
+         * @param o1
+         * @param o2
+         * @return
+         */
+        @DataTypeHint("Boolean")
+        public Boolean eval(@DataTypeHint("INT") Integer key, @DataTypeHint(value = "RAW", bridgedTo = org.locationtech.jts.geom.Geometry.class) Object o1, @DataTypeHint(value = "RAW", bridgedTo = org.locationtech.jts.geom.Geometry.class) Object o2) {
+            Objects.requireNonNull(grids, "This predicate has to be initialized by a partitioner.");
+            Geometry geom1 = (Geometry) o1;
+            Geometry geom2 = (Geometry) o2;
+            HalfOpenRectangle halfOpenRectangle = new HalfOpenRectangle(grids.get(key));
+            return JudgementHelper.match(geom1, geom2, halfOpenRectangle, true);
+        }
+    }
+
+    public static class ST_Covers extends ScalarFunction {
+        private List<Envelope> grids;
+
+        /**
+         * Constructor for duplicate removal
+         */
+        public ST_Covers(PartitioningUtils partitioner) {
+            grids = partitioner.fetchLeafZones();
+        }
+
+        /**
+         * Constructor for relation checking without duplicate removal
+         */
+        public ST_Covers() {
+        }
+
+        @DataTypeHint("Boolean")
+        public Boolean eval(@DataTypeHint(value = "RAW", bridgedTo = org.locationtech.jts.geom.Geometry.class) Object o1, @DataTypeHint(value = "RAW", bridgedTo = org.locationtech.jts.geom.Geometry.class) Object o2) {
+            Geometry geom1 = (Geometry) o1;
+            Geometry geom2 = (Geometry) o2;
             return geom1.covers(geom2);
         }
 
@@ -102,6 +182,46 @@ public class Predicates {
             Geometry geom2 = (Geometry) o2;
             HalfOpenRectangle halfOpenRectangle = new HalfOpenRectangle(grids.get(key));
             return JudgementHelper.match(geom1, geom2, halfOpenRectangle, false);
+        }
+    }
+
+    public static class ST_CoveredBy extends ScalarFunction {
+        private List<Envelope> grids;
+
+        /**
+         * Constructor for duplicate removal
+         */
+        public ST_CoveredBy(PartitioningUtils partitioner) {
+            grids = partitioner.fetchLeafZones();
+        }
+
+        /**
+         * Constructor for relation checking without duplicate removal
+         */
+        public ST_CoveredBy() {
+        }
+
+        @DataTypeHint("Boolean")
+        public Boolean eval(@DataTypeHint(value = "RAW", bridgedTo = org.locationtech.jts.geom.Geometry.class) Object o1, @DataTypeHint(value = "RAW", bridgedTo = org.locationtech.jts.geom.Geometry.class) Object o2) {
+            Geometry geom1 = (Geometry) o1;
+            Geometry geom2 = (Geometry) o2;
+            return geom1.coveredBy(geom2);
+        }
+
+        /**
+         * Check spatial relation with duplicates removal
+         * @param key
+         * @param o1
+         * @param o2
+         * @return
+         */
+        @DataTypeHint("Boolean")
+        public Boolean eval(@DataTypeHint("INT") Integer key, @DataTypeHint(value = "RAW", bridgedTo = org.locationtech.jts.geom.Geometry.class) Object o1, @DataTypeHint(value = "RAW", bridgedTo = org.locationtech.jts.geom.Geometry.class) Object o2) {
+            Objects.requireNonNull(grids, "This predicate has to be initialized by a partitioner.");
+            Geometry geom1 = (Geometry) o1;
+            Geometry geom2 = (Geometry) o2;
+            HalfOpenRectangle halfOpenRectangle = new HalfOpenRectangle(grids.get(key));
+            return JudgementHelper.match(geom1, geom2, halfOpenRectangle, true);
         }
     }
 

--- a/flink/src/test/java/org/apache/sedona/flink/PredicateTest.java
+++ b/flink/src/test/java/org/apache/sedona/flink/PredicateTest.java
@@ -53,6 +53,33 @@ public class PredicateTest extends TestBase{
     }
 
     @Test
+    public void testWithin() {
+        Table pointTable = createPointTable(testDataSize);
+        String polygon = createPolygonWKT(testDataSize).get(0).getField(0).toString();
+        String expr = "ST_Within(geom_point, ST_GeomFromWkt('" + polygon + "'))";
+        Table result = pointTable.filter(expr);
+        assertEquals(1, count(result));
+    }
+
+    @Test
+    public void testCovers() {
+        Table pointTable = createPointTable(testDataSize);
+        String polygon = createPolygonWKT(testDataSize).get(0).getField(0).toString();
+        String expr = "ST_Covers(ST_GeomFromWkt('" + polygon + "'), geom_point)";
+        Table result = pointTable.filter(expr);
+        assertEquals(1, count(result));
+    }
+
+    @Test
+    public void testCoveredBy() {
+        Table pointTable = createPointTable(testDataSize);
+        String polygon = createPolygonWKT(testDataSize).get(0).getField(0).toString();
+        String expr = "ST_CoveredBy(geom_point, ST_GeomFromWkt('" + polygon + "'))";
+        Table result = pointTable.filter(expr);
+        assertEquals(1, count(result));
+    }
+
+    @Test
     public void testOrderingEquals() {
         Table lineStringTable = createLineStringTable(testDataSize);
         String lineString = createLineStringWKT(testDataSize).get(0).getField(0).toString();

--- a/python/sedona/sql/st_predicates.py
+++ b/python/sedona/sql/st_predicates.py
@@ -145,3 +145,31 @@ def ST_Within(a: ColumnOrName, b: ColumnOrName) -> Column:
     :rtype: Column
     """
     return _call_predicate_function("ST_Within", (a, b))
+
+
+@validate_argument_types
+def ST_Covers(a: ColumnOrName, b: ColumnOrName) -> Column:
+    """Check whether geometry a covers geometry b.
+
+    :param a: Geometry column to check.
+    :type a: ColumnOrName
+    :param b: Geometry column to check.
+    :type b: ColumnOrName
+    :return: True if a covers b and False otherwise, as a boolean column.
+    :rtype: Column
+    """
+    return _call_predicate_function("ST_Covers", (a, b))
+
+
+@validate_argument_types
+def ST_CoveredBy(a: ColumnOrName, b: ColumnOrName) -> Column:
+    """Check if geometry a is covered by geometry b.
+
+    :param a: Geometry column to check.
+    :type a: ColumnOrName
+    :param b: Geometry column to check.
+    :type b: ColumnOrName
+    :return: True if a is covered by b and False otherwise, as a boolean column.
+    :rtype: Column
+    """
+    return _call_predicate_function("ST_CoveredBy", (a, b))

--- a/python/tests/sql/test_dataframe_api.py
+++ b/python/tests/sql/test_dataframe_api.py
@@ -118,6 +118,12 @@ test_configurations = [
     (stp.ST_Overlaps, ("a", "b"), "overlapping_polys", "", True),
     (stp.ST_Touches, ("a", "b"), "touching_polys", "", True),
     (stp.ST_Within, (lambda: f.expr("ST_Point(0.5, 0.25)"), "geom"), "triangle_geom", "", True),
+    (stp.ST_Covers, ("geom", lambda: f.expr("ST_Point(0.5, 0.25)")), "triangle_geom", "", True),
+    (stp.ST_CoveredBy, (lambda: f.expr("ST_Point(0.5, 0.25)"), "geom"), "triangle_geom", "", True),
+    (stp.ST_Contains, ("geom", lambda: f.expr("ST_Point(0.0, 0.0)")), "triangle_geom", "", False),
+    (stp.ST_Within, (lambda: f.expr("ST_Point(0.0, 0.0)"), "geom"), "triangle_geom", "", False),
+    (stp.ST_Covers, ("geom", lambda: f.expr("ST_Point(0.0, 0.0)")), "triangle_geom", "", True),
+    (stp.ST_CoveredBy, (lambda: f.expr("ST_Point(0.0, 0.0)"), "geom"), "triangle_geom", "", True),
 
     # aggregates
     (sta.ST_Envelope_Aggr, ("geom",), "exploded_points", "", "POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0))"),

--- a/sql/src/main/scala/org/apache/sedona/sql/UDF/Catalog.scala
+++ b/sql/src/main/scala/org/apache/sedona/sql/UDF/Catalog.scala
@@ -43,6 +43,8 @@ object Catalog {
     ST_Contains,
     ST_Intersects,
     ST_Within,
+    ST_Covers,
+    ST_CoveredBy,
     ST_Disjoint,
     ST_Distance,
     ST_3DDistance,

--- a/sql/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/Predicates.scala
+++ b/sql/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/Predicates.scala
@@ -53,7 +53,7 @@ case class ST_Contains(inputExpressions: Seq[Expression])
 
     val rightGeometry = GeometrySerializer.deserialize(rightArray)
 
-    leftGeometry.covers(rightGeometry)
+    leftGeometry.contains(rightGeometry)
   }
 
   override def dataType = BooleanType
@@ -131,6 +131,75 @@ case class ST_Within(inputExpressions: Seq[Expression])
   }
 }
 
+/**
+  * Test if leftGeometry covers rightGeometry
+  *
+  * @param inputExpressions
+  */
+case class ST_Covers(inputExpressions: Seq[Expression])
+  extends ST_Predicate with CodegenFallback {
+
+  // This is a binary expression
+  assert(inputExpressions.length == 2)
+
+  override def nullable: Boolean = false
+
+  override def toString: String = s" **${ST_Covers.getClass.getName}**  "
+
+  override def children: Seq[Expression] = inputExpressions
+
+  override def eval(inputRow: InternalRow): Any = {
+    val leftArray = inputExpressions(0).eval(inputRow).asInstanceOf[ArrayData]
+    val rightArray = inputExpressions(1).eval(inputRow).asInstanceOf[ArrayData]
+
+    val leftGeometry = GeometrySerializer.deserialize(leftArray)
+
+    val rightGeometry = GeometrySerializer.deserialize(rightArray)
+
+    leftGeometry.covers(rightGeometry)
+  }
+
+  override def dataType = BooleanType
+
+  protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
+    copy(inputExpressions = newChildren)
+  }
+}
+
+/**
+  * Test if leftGeometry is covered by rightGeometry
+  *
+  * @param inputExpressions
+  */
+case class ST_CoveredBy(inputExpressions: Seq[Expression])
+  extends ST_Predicate with CodegenFallback {
+
+  // This is a binary expression
+  assert(inputExpressions.length == 2)
+
+  override def nullable: Boolean = false
+
+  override def toString: String = s" **${ST_CoveredBy.getClass.getName}**  "
+
+  override def children: Seq[Expression] = inputExpressions
+
+  override def eval(inputRow: InternalRow): Any = {
+    val leftArray = inputExpressions(0).eval(inputRow).asInstanceOf[ArrayData]
+    val rightArray = inputExpressions(1).eval(inputRow).asInstanceOf[ArrayData]
+
+    val leftGeometry = GeometrySerializer.deserialize(leftArray)
+
+    val rightGeometry = GeometrySerializer.deserialize(rightArray)
+
+    leftGeometry.coveredBy(rightGeometry)
+  }
+
+  override def dataType = BooleanType
+
+  protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
+    copy(inputExpressions = newChildren)
+  }
+}
 
 /**
   * Test if leftGeometry crosses rightGeometry

--- a/sql/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/st_predicates.scala
+++ b/sql/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/st_predicates.scala
@@ -48,4 +48,10 @@ object st_predicates extends DataFrameAPI {
 
   def ST_Within(a: Column, b: Column): Column = wrapExpression[ST_Within](a, b)
   def ST_Within(a: String, b: String): Column = wrapExpression[ST_Within](a, b)
+
+  def ST_Covers(a: Column, b: Column): Column = wrapExpression[ST_Covers](a, b)
+  def ST_Covers(a: String, b: String): Column = wrapExpression[ST_Covers](a, b)
+
+  def ST_CoveredBy(a: Column, b: Column): Column = wrapExpression[ST_CoveredBy](a, b)
+  def ST_CoveredBy(a: String, b: String): Column = wrapExpression[ST_CoveredBy](a, b)
 }

--- a/sql/src/main/scala/org/apache/spark/sql/sedona_sql/strategy/join/JoinQueryDetector.scala
+++ b/sql/src/main/scala/org/apache/spark/sql/sedona_sql/strategy/join/JoinQueryDetector.scala
@@ -61,6 +61,10 @@ class JoinQueryDetector(sparkSession: SparkSession) extends Strategy {
           Some(JoinQueryDetection(left, right, leftShape, rightShape, true, extraCondition))
         case ST_Within(Seq(leftShape, rightShape)) =>
           Some(JoinQueryDetection(right, left, rightShape, leftShape, false, extraCondition))
+        case ST_Covers(Seq(leftShape, rightShape)) =>
+          Some(JoinQueryDetection(left, right, leftShape, rightShape, false, extraCondition))
+        case ST_CoveredBy(Seq(leftShape, rightShape)) =>
+          Some(JoinQueryDetection(right, left, rightShape, leftShape, false, extraCondition))
         case ST_Overlaps(Seq(leftShape, rightShape)) =>
           Some(JoinQueryDetection(right, left, rightShape, leftShape, false, extraCondition))
         case ST_Touches(Seq(leftShape, rightShape)) =>

--- a/sql/src/test/scala/org/apache/sedona/sql/dataFrameAPITestScala.scala
+++ b/sql/src/test/scala/org/apache/sedona/sql/dataFrameAPITestScala.scala
@@ -807,6 +807,22 @@ class dataFrameAPITestScala extends TestBaseScala {
       assert(!actualResult)
     }
 
+    it("Passed ST_Covers") {
+      val baseDf = sparkSession.sql("SELECT ST_GeomFromWKT('POLYGON ((0 0, 1 0, 1 1, 0 0))') AS a, ST_Point(1.0, 0.0) AS b, ST_Point(0.0, 1.0) AS c")
+      val df = baseDf.select(ST_Covers("a", "b"), ST_Covers("a", "c"))
+      val actualResult = df.take(1)(0)
+      assert(actualResult.getBoolean(0))
+      assert(!actualResult.getBoolean(1))
+    }
+
+    it("Passed ST_CoveredBy") {
+      val baseDf = sparkSession.sql("SELECT ST_GeomFromWKT('POLYGON ((0 0, 1 0, 1 1, 0 0))') AS a, ST_Point(1.0, 0.0) AS b, ST_Point(0.0, 1.0) AS c")
+      val df = baseDf.select(ST_CoveredBy("b", "a"), ST_CoveredBy("c", "a"))
+      val actualResult = df.take(1)(0)
+      assert(actualResult.getBoolean(0))
+      assert(!actualResult.getBoolean(1))
+    }
+
     // aggregates
     it("Passed ST_Envelope_Aggr") {
       val baseDf = sparkSession.sql("SELECT explode(array(ST_Point(0.0, 0.0), ST_Point(1.0, 1.0))) AS geom")


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read [Contributor Rules](https://sedona.apache.org/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/community/develop/)

## Is this PR related to a JIRA ticket?

- Yes, the URL of the assoicated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-176. The PR name follows the format `[SEDONA-176] my subject`.

## What changes were proposed in this PR?

* `ST_Contains` in Spark SQL module calls JTS function `contains` instead of `covers`.
* Added `ST_Covers`, which calls JTS function `covers`.
* Added `ST_CoveredBy`, which calls JTS function `coveredBy`.
* Added dataframe functions for `ST_Covers` and `ST_CoveredBy`.

## How was this patch tested?

Unit tests were added in this patch.

## Did this PR include necessary documentation updates?

- Yes, I am adding a new API. I am using the [current SNAPSHOT version number](https://github.com/apache/incubator-sedona/blob/master/pom.xml#L29) in since `vX.Y.Z` format.
