### PR TITLE
[SEDONA-178] Correctness issue in distance joins

### DIFF
--- a/docs/tutorial/core-python.md
+++ b/docs/tutorial/core-python.md
@@ -450,6 +450,8 @@ Each object on the left is covered/intersected by the object on the right.
 
 ## Write a Distance Join Query
 
+!!!warning RDD distance joins are only reliable for points. For other geometry types, please use Spatial SQL.
+
 A distance join query takes two spatial RDD assuming that we have two SpatialRDD's:
 <li> object_rdd </li>
 <li> spatial_rdd </li>

--- a/docs/tutorial/rdd.md
+++ b/docs/tutorial/rdd.md
@@ -466,6 +466,8 @@ Each object on the left is covered/intersected by the object on the right.
 
 ## Write a Distance Join Query
 
+!!!warning RDD distance joins are only reliable for points. For other geometry types, please use Spatial SQL.
+
 A distance join query takes as input two Spatial RDD A and B and a distance. For each geometry in A, finds the geometries (from B) are within the given distance to it. A and B can be any geometry type and are not necessary to have the same geometry type. The unit of the distance is explained [here](#transform-the-coordinate-reference-system).
 
 Assume you now have two SpatialRDDs (typed or generic). You can use the following code to issue an Distance Join Query on them.

--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,10 @@
         <sedona.jackson.version>2.13.3</sedona.jackson.version>
         <hadoop.version>3.2.4</hadoop.version>
         <maven.deploy.skip>false</maven.deploy.skip>
+
+        <!-- Actual scala version will be set by a profile.
+        Setting a default value helps IDE:s that can't make sense of profiles. -->
+        <scala.compat.version>2.12</scala.compat.version>
     </properties>
 
     <dependencies>

--- a/sql/src/main/scala/org/apache/spark/sql/sedona_sql/strategy/join/DistanceJoinExec.scala
+++ b/sql/src/main/scala/org/apache/spark/sql/sedona_sql/strategy/join/DistanceJoinExec.scala
@@ -18,54 +18,53 @@
  */
 package org.apache.spark.sql.sedona_sql.strategy.join
 
-import org.apache.sedona.common.geometryObjects.Circle
 import org.apache.sedona.core.spatialOperator.SpatialPredicate
 import org.apache.sedona.core.spatialRDD.SpatialRDD
-import org.apache.sedona.sql.utils.GeometrySerializer
 import org.apache.spark.internal.Logging
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.expressions.{BindReferences, Expression, UnsafeRow}
-import org.apache.spark.sql.catalyst.util.ArrayData
 import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.sedona_sql.execution.SedonaBinaryExecNode
 import org.locationtech.jts.geom.Geometry
 
-// ST_Distance(left, right) <= radius
-// radius can be literal or a computation over 'left'
+/**
+ * Distance joins requires matching geometries to be in the same partition, despite not necessarily overlapping.
+ * To create an overlap and guarantee matching geometries end up in the same partition, the left geometry is expanded
+ * before partitioning. It's the logical equivalent of:
+ *
+ * select * from a join b on ST_Distance(a.geom, b.geom) <= 1
+ *
+ * becomes
+ *
+ * select * from a join b on ST_Intersects(ST_Envelope(ST_Buffer(a.geom, 1)), b.geom) and ST_Distance(a.geom, b.geom) <= 1
+ *
+ * @param left
+ * @param right
+ * @param leftShape
+ * @param rightShape
+ * @param distance - ST_Distance(left, right) <= distance. Distance can be literal or a computation over 'left'.
+ * @param spatialPredicate
+ * @param extraCondition
+ */
 case class DistanceJoinExec(left: SparkPlan,
                             right: SparkPlan,
                             leftShape: Expression,
                             rightShape: Expression,
-                            radius: Expression,
+                            distance: Expression,
                             spatialPredicate: SpatialPredicate,
                             extraCondition: Option[Expression] = None)
   extends SedonaBinaryExecNode
     with TraitJoinQueryExec
     with Logging {
 
-  private val boundRadius = BindReferences.bindReference(radius, left.output)
+  private val boundRadius = BindReferences.bindReference(distance, left.output)
 
   override def toSpatialRddPair(
                                  buildRdd: RDD[UnsafeRow],
                                  buildExpr: Expression,
                                  streamedRdd: RDD[UnsafeRow],
                                  streamedExpr: Expression): (SpatialRDD[Geometry], SpatialRDD[Geometry]) =
-    (toCircleRDD(buildRdd, buildExpr), toSpatialRDD(streamedRdd, streamedExpr))
-
-  private def toCircleRDD(rdd: RDD[UnsafeRow], shapeExpression: Expression): SpatialRDD[Geometry] = {
-    val spatialRdd = new SpatialRDD[Geometry]
-    spatialRdd.setRawSpatialRDD(
-      rdd
-        .map { x => {
-          val shape = GeometrySerializer.deserialize(shapeExpression.eval(x).asInstanceOf[ArrayData])
-          val circle = new Circle(shape, boundRadius.eval(x).asInstanceOf[Double])
-          circle.setUserData(x.copy)
-          circle.asInstanceOf[Geometry]
-        }
-        }
-        .toJavaRDD())
-    spatialRdd
-  }
+    (toExpandedEnvelopeRDD(buildRdd, buildExpr, boundRadius), toSpatialRDD(streamedRdd, streamedExpr))
 
   protected def withNewChildrenInternal(newLeft: SparkPlan, newRight: SparkPlan): SparkPlan = {
     copy(left = newLeft, right = newRight)

--- a/sql/src/main/scala/org/apache/spark/sql/sedona_sql/strategy/join/SpatialIndexExec.scala
+++ b/sql/src/main/scala/org/apache/spark/sql/sedona_sql/strategy/join/SpatialIndexExec.scala
@@ -33,7 +33,7 @@ import org.apache.spark.sql.sedona_sql.execution.SedonaUnaryExecNode
 case class SpatialIndexExec(child: SparkPlan,
                             shape: Expression,
                             indexType: IndexType,
-                            radius: Option[Expression] = None)
+                            distance: Option[Expression] = None)
   extends SedonaUnaryExecNode
     with TraitJoinQueryBase
     with Logging {
@@ -50,8 +50,8 @@ case class SpatialIndexExec(child: SparkPlan,
 
     val resultRaw = child.execute().asInstanceOf[RDD[UnsafeRow]].coalesce(1)
 
-    val spatialRDD = radius match {
-      case Some(radiusExpression) => toCircleRDD(resultRaw, boundShape, BindReferences.bindReference(radiusExpression, child.output))
+    val spatialRDD = distance match {
+      case Some(distanceExpression) => toExpandedEnvelopeRDD(resultRaw, boundShape, BindReferences.bindReference(distanceExpression, child.output))
       case None => toSpatialRDD(resultRaw, boundShape)
     }
 

--- a/sql/src/test/scala/org/apache/sedona/sql/SpatialJoinSuite.scala
+++ b/sql/src/test/scala/org/apache/sedona/sql/SpatialJoinSuite.scala
@@ -128,11 +128,10 @@ class SpatialJoinSuite extends TestBaseScala with TableDrivenPropertyChecks {
       case "ST_Touches" => (l: Geometry, r: Geometry) => l.touches(r)
       case "ST_Within" => (l: Geometry, r: Geometry) => l.within(r)
       case "ST_Distance" =>
-        // XXX: ST_Distance has a weird behavior, it is wildly different from `l.distance(r)`.
         if (joinCondition.contains("<=")) {
-          (l: Geometry, r: Geometry) => new Circle(l, 1.0).intersects(r)
+          (l: Geometry, r: Geometry) => l.distance(r) <= 1.0
         } else {
-          (l: Geometry, r: Geometry) => new Circle(l, 1.0).covers(r)
+          (l: Geometry, r: Geometry) => l.distance(r) < 1.0
         }
     }
     left.flatMap { case (id, geom) =>


### PR DESCRIPTION

## Did you read the Contributor Guide?

- Yes, I have read [Contributor Rules](https://sedona.apache.org/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/community/develop/)

## Is this PR related to a JIRA ticket?

- Yes, the URL of the assoicated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-178. The PR name follows the format `[SEDONA-178] my subject`.


## What changes were proposed in this PR?

Sedona SQL doesn't rely on Circle for distance joins. Correct results are now produces for all geometry types.

Performance could be improved but would require some refactoring of the spatial partitioning code.

See the jira for discussion.

## How was this patch tested?

All unit tests pass. New tests added.

## Did this PR include necessary documentation updates?

- Yes, I have updated the documentation update.
