### PR TITLE
[SEDONA-181] Bump scalatest-maven-plugin to make it respect JAVA_HOME

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -415,7 +415,7 @@
             <plugin>
                 <groupId>org.scalatest</groupId>
                 <artifactId>scalatest-maven-plugin</artifactId>
-                <version>1.0</version>
+                <version>2.2.0</version>
                 <configuration>
                     <reportsDirectory>${project.build.directory}/surefire-reports</reportsDirectory>
                     <junitxml>.</junitxml>


### PR DESCRIPTION

## Did you read the Contributor Guide?

- Yes, I have read [Contributor Rules](https://sedona.apache.org/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/community/develop/)

~~- No, I haven't read it.~~

## Is this PR related to a JIRA ticket?

- Yes SEDONA-181


~~- No, this is a documentation update. The PR name follows the format `[DOCS] my subject`.~~


## What changes were proposed in this PR?
Update `scalatest-maven-plugin` version because of https://github.com/scalatest/scalatest-maven-plugin/issues/26

## How was this patch tested?
`mvn clean install` in env where `JAVA_HOME` points to java8 and default java is 19

## Did this PR include necessary documentation updates?

~~- Yes, I am adding a new API. I am using the [current SNAPSHOT version number](https://github.com/apache/incubator-sedona/blob/master/pom.xml#L29) in since `vX.Y.Z` format.~~
~~- Yes, I have updated the documentation update.~~
- No, this PR does not affect any public API so no need to change the docs.
