### PR TITLE
[SEDONA-180] Make ST_* expressions foldable and declares input types for type checking

### DIFF
--- a/python/tests/sql/test_dataframe_api.py
+++ b/python/tests/sql/test_dataframe_api.py
@@ -79,7 +79,7 @@ test_configurations = [
     (stf.ST_MakeValid, ("geom",), "invalid_geom", "", "MULTIPOLYGON (((1 5, 3 3, 1 1, 1 5)), ((5 3, 7 5, 7 1, 5 3)))"),
     (stf.ST_MakePolygon, ("geom",), "closed_linestring_geom", "", "POLYGON ((0 0, 1 0, 1 1, 0 0))"),
     (stf.ST_MinimumBoundingCircle, ("line",), "linestring_geom", "ST_PrecisionReduce(geom, 2)", "POLYGON ((4.95 -0.49, 4.81 -0.96, 4.58 -1.39, 4.27 -1.77, 3.89 -2.08, 3.46 -2.31, 2.99 -2.45, 2.5 -2.5, 2.01 -2.45, 1.54 -2.31, 1.11 -2.08, 0.73 -1.77, 0.42 -1.39, 0.19 -0.96, 0.05 -0.49, 0 0, 0.05 0.49, 0.19 0.96, 0.42 1.39, 0.73 1.77, 1.11 2.08, 1.54 2.31, 2.01 2.45, 2.5 2.5, 2.99 2.45, 3.46 2.31, 3.89 2.08, 4.27 1.77, 4.58 1.39, 4.81 0.96, 4.95 0.49, 5 0, 4.95 -0.49))"),
-    (stf.ST_MinimumBoundingCircle, ("line", 2), "linestring_geom", "ST_PrecisionReduce(geom, 2)", "POLYGON ((4.95 -0.49, 4.81 -0.96, 4.58 -1.39, 4.27 -1.77, 3.89 -2.08, 3.46 -2.31, 2.99 -2.45, 2.5 -2.5, 2.01 -2.45, 1.54 -2.31, 1.11 -2.08, 0.73 -1.77, 0.42 -1.39, 0.19 -0.96, 0.05 -0.49, 0 0, 0.05 0.49, 0.19 0.96, 0.42 1.39, 0.73 1.77, 1.11 2.08, 1.54 2.31, 2.01 2.45, 2.5 2.5, 2.99 2.45, 3.46 2.31, 3.89 2.08, 4.27 1.77, 4.58 1.39, 4.81 0.96, 4.95 0.49, 5 0, 4.95 -0.49))"),
+    (stf.ST_MinimumBoundingCircle, ("line", 2), "linestring_geom", "ST_PrecisionReduce(geom, 2)", "POLYGON ((4.27 -1.77, 2.5 -2.5, 0.73 -1.77, 0 0, 0.73 1.77, 2.5 2.5, 4.27 1.77, 5 0, 4.27 -1.77))"),
     (stf.ST_MinimumBoundingRadius, ("line",), "linestring_geom", "", {"center": "POINT (2.5 0)", "radius": 2.5}),
     (stf.ST_Multi, ("point",), "point_geom", "", "MULTIPOINT (0 1)"),
     (stf.ST_Normalize, ("geom",), "triangle_geom", "", "POLYGON ((0 0, 1 1, 1 0, 0 0))"),

--- a/sql/src/main/scala/org/apache/sedona/sql/UDF/Catalog.scala
+++ b/sql/src/main/scala/org/apache/sedona/sql/UDF/Catalog.scala
@@ -18,140 +18,149 @@
  */
 package org.apache.sedona.sql.UDF
 
+import org.apache.spark.sql.catalyst.FunctionIdentifier
+import org.apache.spark.sql.catalyst.expressions.{ExpectsInputTypes, Expression, ExpressionInfo}
+import org.apache.spark.sql.catalyst.expressions.Literal
 import org.apache.spark.sql.catalyst.analysis.FunctionRegistry.FunctionBuilder
 import org.apache.spark.sql.expressions.{Aggregator, UserDefinedAggregateFunction}
 import org.apache.spark.sql.sedona_sql.expressions.{ST_YMax, ST_YMin, _}
 import org.apache.spark.sql.sedona_sql.expressions.collect.{ST_Collect, ST_CollectionExtract}
 import org.apache.spark.sql.sedona_sql.expressions.raster.{RS_Add, RS_Append, RS_Array, RS_Base64, RS_BitwiseAnd, RS_BitwiseOr, RS_Count, RS_Divide, RS_FetchRegion, RS_GetBand, RS_GreaterThan, RS_GreaterThanEqual, RS_HTML, RS_LessThan, RS_LessThanEqual, RS_LogicalDifference, RS_LogicalOver, RS_Mean, RS_Mode, RS_Modulo, RS_Multiply, RS_MultiplyFactor, RS_Normalize, RS_NormalizedDifference, RS_SquareRoot, RS_Subtract}
 import org.locationtech.jts.geom.Geometry
+import org.locationtech.jts.operation.buffer.BufferParameters
+
+import scala.reflect.ClassTag
 
 object Catalog {
-  val expressions: Seq[FunctionBuilder] = Seq(
+
+  type FunctionDescription = (FunctionIdentifier, ExpressionInfo, FunctionBuilder)
+
+  val expressions: Seq[FunctionDescription] = Seq(
     // Expression for vectors
-    ST_PointFromText,
-    ST_PolygonFromText,
-    ST_LineStringFromText,
-    ST_GeomFromText,
-    ST_LineFromText,
-    ST_GeomFromWKT,
-    ST_GeomFromWKB,
-    ST_GeomFromGeoJSON,
-    ST_GeomFromGML,
-    ST_GeomFromKML,
-    ST_Point,
-    ST_PolygonFromEnvelope,
-    ST_Contains,
-    ST_Intersects,
-    ST_Within,
-    ST_Covers,
-    ST_CoveredBy,
-    ST_Disjoint,
-    ST_Distance,
-    ST_3DDistance,
-    ST_ConvexHull,
-    ST_NPoints,
-    ST_Buffer,
-    ST_Envelope,
-    ST_Length,
-    ST_Area,
-    ST_Centroid,
-    ST_Transform,
-    ST_Intersection,
-    ST_Difference,
-    ST_SymDifference,
-    ST_Union,
-    ST_IsValid,
-    ST_IsEmpty,
-    ST_PrecisionReduce,
-    ST_Equals,
-    ST_Touches,
-    ST_Overlaps,
-    ST_Crosses,
-    ST_IsSimple,
-    ST_MakeValid,
-    ST_SimplifyPreserveTopology,
-    ST_AsText,
-    ST_AsGeoJSON,
-    ST_AsBinary,
-    ST_AsEWKB,
-    ST_AsGML,
-    ST_AsKML,
-    ST_SRID,
-    ST_SetSRID,
-    ST_GeometryType,
-    ST_NumGeometries,
-    ST_LineMerge,
-    ST_Azimuth,
-    ST_X,
-    ST_Y,
-    ST_Z,
-    ST_StartPoint,
-    ST_Boundary,
-    ST_MinimumBoundingRadius,
-    ST_MinimumBoundingCircle,
-    ST_EndPoint,
-    ST_ExteriorRing,
-    ST_GeometryN,
-    ST_InteriorRingN,
-    ST_Dump,
-    ST_DumpPoints,
-    ST_IsClosed,
-    ST_NumInteriorRings,
-    ST_AddPoint,
-    ST_RemovePoint,
-    ST_SetPoint,
-    ST_IsRing,
-    ST_FlipCoordinates,
-    ST_LineSubstring,
-    ST_LineInterpolatePoint,
-    ST_SubDivideExplode,
-    ST_SubDivide,
-    ST_MakePolygon,
-    ST_GeoHash,
-    ST_GeomFromGeoHash,
-    ST_Collect,
-    ST_Multi,
-    ST_PointOnSurface,
-    ST_Reverse,
-    ST_PointN,
-    ST_AsEWKT,
-    ST_Force_2D,
-    ST_YMax,
-    ST_YMin,
-    ST_XMax,
-    ST_XMin,
-    ST_BuildArea,
-    ST_OrderingEquals,
-    ST_CollectionExtract,
-    ST_Normalize,
-    ST_LineFromMultiPoint,
+    function[ST_PointFromText](),
+    function[ST_PolygonFromText](),
+    function[ST_LineStringFromText](),
+    function[ST_GeomFromText](),
+    function[ST_LineFromText](),
+    function[ST_GeomFromWKT](),
+    function[ST_GeomFromWKB](),
+    function[ST_GeomFromGeoJSON](),
+    function[ST_GeomFromGML](),
+    function[ST_GeomFromKML](),
+    function[ST_Point](null),
+    function[ST_PolygonFromEnvelope](),
+    function[ST_Contains](),
+    function[ST_Intersects](),
+    function[ST_Within](),
+    function[ST_Covers](),
+    function[ST_CoveredBy](),
+    function[ST_Disjoint](),
+    function[ST_Distance](),
+    function[ST_3DDistance](),
+    function[ST_ConvexHull](),
+    function[ST_NPoints](),
+    function[ST_Buffer](),
+    function[ST_Envelope](),
+    function[ST_Length](),
+    function[ST_Area](),
+    function[ST_Centroid](),
+    function[ST_Transform](false),
+    function[ST_Intersection](),
+    function[ST_Difference](),
+    function[ST_SymDifference](),
+    function[ST_Union](),
+    function[ST_IsValid](),
+    function[ST_IsEmpty](),
+    function[ST_PrecisionReduce](),
+    function[ST_Equals](),
+    function[ST_Touches](),
+    function[ST_Overlaps](),
+    function[ST_Crosses](),
+    function[ST_IsSimple](),
+    function[ST_MakeValid](false),
+    function[ST_SimplifyPreserveTopology](),
+    function[ST_AsText](),
+    function[ST_AsGeoJSON](),
+    function[ST_AsBinary](),
+    function[ST_AsEWKB](),
+    function[ST_AsGML](),
+    function[ST_AsKML](),
+    function[ST_SRID](),
+    function[ST_SetSRID](),
+    function[ST_GeometryType](),
+    function[ST_NumGeometries](),
+    function[ST_LineMerge](),
+    function[ST_Azimuth](),
+    function[ST_X](),
+    function[ST_Y](),
+    function[ST_Z](),
+    function[ST_StartPoint](),
+    function[ST_Boundary](),
+    function[ST_MinimumBoundingRadius](),
+    function[ST_MinimumBoundingCircle](BufferParameters.DEFAULT_QUADRANT_SEGMENTS),
+    function[ST_EndPoint](),
+    function[ST_ExteriorRing](),
+    function[ST_GeometryN](),
+    function[ST_InteriorRingN](),
+    function[ST_Dump](),
+    function[ST_DumpPoints](),
+    function[ST_IsClosed](),
+    function[ST_NumInteriorRings](),
+    function[ST_AddPoint](-1),
+    function[ST_RemovePoint](-1),
+    function[ST_SetPoint](),
+    function[ST_IsRing](),
+    function[ST_FlipCoordinates](),
+    function[ST_LineSubstring](),
+    function[ST_LineInterpolatePoint](),
+    function[ST_SubDivideExplode](),
+    function[ST_SubDivide](),
+    function[ST_MakePolygon](),
+    function[ST_GeoHash](),
+    function[ST_GeomFromGeoHash](null),
+    function[ST_Collect](),
+    function[ST_Multi](),
+    function[ST_PointOnSurface](),
+    function[ST_Reverse](),
+    function[ST_PointN](),
+    function[ST_AsEWKT](),
+    function[ST_Force_2D](),
+    function[ST_YMax](),
+    function[ST_YMin](),
+    function[ST_XMax](),
+    function[ST_XMin](),
+    function[ST_BuildArea](),
+    function[ST_OrderingEquals](),
+    function[ST_CollectionExtract](),
+    function[ST_Normalize](),
+    function[ST_LineFromMultiPoint](),
     // Expression for rasters
-    RS_NormalizedDifference,
-    RS_Mean,
-    RS_Mode,
-    RS_FetchRegion,
-    RS_GreaterThan,
-    RS_GreaterThanEqual,
-    RS_LessThan,
-    RS_LessThanEqual,
-    RS_Add,
-    RS_Subtract,
-    RS_Divide,
-    RS_MultiplyFactor,
-    RS_Multiply,
-    RS_BitwiseAnd,
-    RS_BitwiseOr,
-    RS_Count,
-    RS_Modulo,
-    RS_GetBand,
-    RS_SquareRoot,
-    RS_LogicalDifference,
-    RS_LogicalOver,
-    RS_Base64,
-    RS_HTML,
-    RS_Array,
-    RS_Normalize,
-    RS_Append
+    function[RS_NormalizedDifference](),
+    function[RS_Mean](),
+    function[RS_Mode](),
+    function[RS_FetchRegion](),
+    function[RS_GreaterThan](),
+    function[RS_GreaterThanEqual](),
+    function[RS_LessThan](),
+    function[RS_LessThanEqual](),
+    function[RS_Add](),
+    function[RS_Subtract](),
+    function[RS_Divide](),
+    function[RS_MultiplyFactor](),
+    function[RS_Multiply](),
+    function[RS_BitwiseAnd](),
+    function[RS_BitwiseOr](),
+    function[RS_Count](),
+    function[RS_Modulo](),
+    function[RS_GetBand](),
+    function[RS_SquareRoot](),
+    function[RS_LogicalDifference](),
+    function[RS_LogicalOver](),
+    function[RS_Base64](),
+    function[RS_HTML](),
+    function[RS_Array](),
+    function[RS_Normalize](),
+    function[RS_Append]()
   )
 
   val aggregateExpressions: Seq[Aggregator[Geometry, Geometry, Geometry]] = Seq(
@@ -166,4 +175,42 @@ object Catalog {
     new expressions_udaf.ST_Envelope_Aggr,
     new expressions_udaf.ST_Intersection_Aggr
   )
+
+  private def function[T <: Expression : ClassTag](defaultArgs: Any *): FunctionDescription = {
+    val classTag = implicitly[ClassTag[T]]
+    val constructor = classTag.runtimeClass.getConstructor(classOf[Seq[Expression]])
+    val functionName = classTag.runtimeClass.getSimpleName
+    val functionIdentifier = FunctionIdentifier(functionName)
+    val expressionInfo = new ExpressionInfo(
+      classTag.runtimeClass.getCanonicalName,
+      functionIdentifier.database.orNull,
+      functionName)
+
+    def functionBuilder(expressions: Seq[Expression]): T = {
+      val expr = constructor.newInstance(expressions).asInstanceOf[T]
+      expr match {
+        case e: ExpectsInputTypes =>
+          val numParameters = e.inputTypes.size
+          val numArguments = expressions.size
+          if (numParameters == numArguments) expr else {
+            val numUnspecifiedArgs = numParameters - numArguments
+            if (numUnspecifiedArgs > 0) {
+              if (numUnspecifiedArgs <= defaultArgs.size) {
+                val args = expressions ++ defaultArgs.takeRight(numUnspecifiedArgs).map(Literal(_))
+                constructor.newInstance(args).asInstanceOf[T]
+              } else {
+                throw new IllegalArgumentException(s"function $functionName takes at least " +
+                  s"${numParameters - defaultArgs.size} argument(s), $numArguments argument(s) specified")
+              }
+            } else {
+              throw new IllegalArgumentException(s"function $functionName takes at most " +
+                s"$numParameters argument(s), $numArguments argument(s) specified")
+            }
+          }
+        case _ => expr
+      }
+    }
+
+    (functionIdentifier, expressionInfo, functionBuilder)
+  }
 }

--- a/sql/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/Constructors.scala
+++ b/sql/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/Constructors.scala
@@ -27,13 +27,17 @@ import org.apache.spark.sql.catalyst.expressions.codegen.CodegenFallback
 import org.apache.spark.sql.catalyst.util.GenericArrayData
 import org.apache.spark.sql.sedona_sql.UDT.GeometryUDT
 import org.apache.spark.sql.sedona_sql.expressions.geohash.GeoHashDecoder
-import org.apache.spark.sql.sedona_sql.expressions.implicits.{GeometryEnhancer, InputExpressionEnhancer, SequenceEnhancer}
-import org.apache.spark.sql.types.{BinaryType, DataType, Decimal, StringType}
+import org.apache.spark.sql.sedona_sql.expressions.implicits.GeometryEnhancer
+import org.apache.spark.sql.types.{AbstractDataType, DataType, DoubleType, IntegerType, StringType, TypeCollection}
 import org.apache.spark.unsafe.types.UTF8String
 import org.locationtech.jts.geom.{Coordinate, GeometryFactory}
 import org.locationtech.jts.io.WKBReader
 import org.locationtech.jts.io.gml2.GMLReader
 import org.locationtech.jts.io.kml.KMLReader
+import org.apache.spark.sql.catalyst.expressions.ExpectsInputTypes
+import org.apache.spark.sql.catalyst.expressions.ImplicitCastInputTypes
+import org.apache.commons.collections.collection.TypedCollection
+import org.apache.spark.sql.types.BinaryType
 
 /**
   * Return a point from a string. The string must be plain string and each coordinate must be separated by a delimiter.
@@ -42,7 +46,7 @@ import org.locationtech.jts.io.kml.KMLReader
   *                         string, the second parameter is the delimiter. String format should be similar to CSV/TSV
   */
 case class ST_PointFromText(inputExpressions: Seq[Expression])
-  extends Expression with CodegenFallback with UserDataGeneratator {
+  extends Expression with FoldableExpression with ImplicitCastInputTypes with CodegenFallback with UserDataGeneratator {
   // This is an expression which takes two input expressions.
   assert(inputExpressions.length == 2)
 
@@ -59,6 +63,8 @@ case class ST_PointFromText(inputExpressions: Seq[Expression])
 
   override def dataType: DataType = GeometryUDT
 
+  override def inputTypes: Seq[AbstractDataType] = Seq(StringType, StringType)
+
   override def children: Seq[Expression] = inputExpressions
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -72,7 +78,7 @@ case class ST_PointFromText(inputExpressions: Seq[Expression])
   * @param inputExpressions
   */
 case class ST_PolygonFromText(inputExpressions: Seq[Expression])
-  extends Expression with CodegenFallback with UserDataGeneratator {
+  extends Expression with FoldableExpression with ImplicitCastInputTypes with CodegenFallback with UserDataGeneratator {
   // This is an expression which takes two input expressions.
   assert(inputExpressions.length == 2)
 
@@ -90,6 +96,8 @@ case class ST_PolygonFromText(inputExpressions: Seq[Expression])
 
   override def dataType: DataType = GeometryUDT
 
+  override def inputTypes: Seq[AbstractDataType] = Seq(StringType, StringType)
+
   override def children: Seq[Expression] = inputExpressions
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -103,7 +111,7 @@ case class ST_PolygonFromText(inputExpressions: Seq[Expression])
   * @param inputExpressions
   */
 case class ST_LineFromText(inputExpressions: Seq[Expression])
-  extends Expression with CodegenFallback with UserDataGeneratator {
+  extends Expression with FoldableExpression with ImplicitCastInputTypes with CodegenFallback with UserDataGeneratator {
   // This is an expression which takes one input expressions.
   assert(inputExpressions.length == 1)
 
@@ -124,6 +132,8 @@ case class ST_LineFromText(inputExpressions: Seq[Expression])
 
   override def dataType: DataType = GeometryUDT
 
+  override def inputTypes: Seq[AbstractDataType] = Seq(StringType)
+
   override def children: Seq[Expression] = inputExpressions
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -137,7 +147,7 @@ case class ST_LineFromText(inputExpressions: Seq[Expression])
   * @param inputExpressions
   */
 case class ST_LineStringFromText(inputExpressions: Seq[Expression])
-  extends Expression with CodegenFallback with UserDataGeneratator {
+  extends Expression with FoldableExpression with ImplicitCastInputTypes with CodegenFallback with UserDataGeneratator {
   // This is an expression which takes two input expressions.
   assert(inputExpressions.length == 2)
 
@@ -156,6 +166,8 @@ case class ST_LineStringFromText(inputExpressions: Seq[Expression])
 
   override def dataType: DataType = GeometryUDT
 
+  override def inputTypes: Seq[AbstractDataType] = Seq(StringType, StringType)
+
   override def children: Seq[Expression] = inputExpressions
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -170,7 +182,7 @@ case class ST_LineStringFromText(inputExpressions: Seq[Expression])
   * @param inputExpressions This function takes 1 parameter which is the geometry string. The string format must be WKT.
   */
 case class ST_GeomFromWKT(inputExpressions: Seq[Expression])
-  extends Expression with CodegenFallback with UserDataGeneratator {
+  extends Expression with FoldableExpression with ImplicitCastInputTypes with CodegenFallback with UserDataGeneratator {
   // This is an expression which takes one input expressions
   assert(inputExpressions.length == 1)
 
@@ -188,6 +200,8 @@ case class ST_GeomFromWKT(inputExpressions: Seq[Expression])
   }
 
   override def dataType: DataType = GeometryUDT
+
+  override def inputTypes: Seq[AbstractDataType] = Seq(StringType)
 
   override def children: Seq[Expression] = inputExpressions
 
@@ -203,11 +217,13 @@ case class ST_GeomFromWKT(inputExpressions: Seq[Expression])
   * @param inputExpressions This function takes 1 parameter which is the geometry string. The string format must be WKT.
   */
 case class ST_GeomFromText(inputExpressions: Seq[Expression])
-  extends Expression with CodegenFallback with UserDataGeneratator {
+  extends Expression with FoldableExpression with ImplicitCastInputTypes with CodegenFallback with UserDataGeneratator with ExpectsInputTypes {
   // This is an expression which takes one input expressions
   assert(inputExpressions.length == 1)
 
   override def nullable: Boolean = true
+
+  override def foldable: Boolean = inputExpressions.forall(_.foldable)
 
   override def eval(inputRow: InternalRow): Any = {
     (inputExpressions(0).eval(inputRow)) match {
@@ -221,6 +237,8 @@ case class ST_GeomFromText(inputExpressions: Seq[Expression])
   }
 
   override def dataType: DataType = GeometryUDT
+
+  override def inputTypes: Seq[AbstractDataType] = Seq(StringType)
 
   override def children: Seq[Expression] = inputExpressions
 
@@ -236,7 +254,7 @@ case class ST_GeomFromText(inputExpressions: Seq[Expression])
   * @param inputExpressions This function takes 1 parameter which is the utf-8 encoded geometry wkb string or the binary wkb array.
   */
 case class ST_GeomFromWKB(inputExpressions: Seq[Expression])
-  extends Expression with CodegenFallback with UserDataGeneratator {
+  extends Expression with FoldableExpression with ImplicitCastInputTypes with CodegenFallback with UserDataGeneratator {
   // This is an expression which takes one input expressions
   assert(inputExpressions.length == 1)
 
@@ -260,6 +278,8 @@ case class ST_GeomFromWKB(inputExpressions: Seq[Expression])
 
   override def dataType: DataType = GeometryUDT
 
+  override def inputTypes: Seq[AbstractDataType] = Seq(TypeCollection(StringType, BinaryType))
+
   override def children: Seq[Expression] = inputExpressions
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -273,7 +293,7 @@ case class ST_GeomFromWKB(inputExpressions: Seq[Expression])
   * @param inputExpressions This function takes 1 parameter which is the geometry string. The string format must be GeoJson.
   */
 case class ST_GeomFromGeoJSON(inputExpressions: Seq[Expression])
-  extends Expression with CodegenFallback with UserDataGeneratator {
+  extends Expression with FoldableExpression with CodegenFallback with UserDataGeneratator {
   // This is an expression which takes one input expressions
   val minInputLength = 1
   assert(inputExpressions.length >= minInputLength)
@@ -305,40 +325,28 @@ case class ST_GeomFromGeoJSON(inputExpressions: Seq[Expression])
 /**
   * Return a Point from X and Y
   *
-  * @param inputExpressions This function takes 2 parameter which are point x and y.
+  * @param inputExpressions This function takes 3 parameter which are point x, y and z.
   */
 case class ST_Point(inputExpressions: Seq[Expression])
-  extends Expression with CodegenFallback with UserDataGeneratator {
-  inputExpressions.betweenLength(2, 3)
+  extends Expression with FoldableExpression with ImplicitCastInputTypes with CodegenFallback with UserDataGeneratator {
 
   override def nullable: Boolean = false
 
   override def eval(inputRow: InternalRow): Any = {
-    val x = inputExpressions(0).eval(inputRow) match {
-      case a: Double => a
-      case b: Decimal => b.toDouble
+    val x = inputExpressions(0).eval(inputRow).asInstanceOf[Double]
+    val y = inputExpressions(1).eval(inputRow).asInstanceOf[Double]
+    val coord = inputExpressions(2).eval(inputRow) match {
+      case null => new Coordinate(x, y)
+      case z: Double => new Coordinate(x, y, z)
     }
-    val y = inputExpressions(1).eval(inputRow) match {
-      case a: Double => a
-      case b: Decimal => b.toDouble
-    }
-
-    val coord = if (inputExpressions.length == 2) {
-      new Coordinate(x, y)
-    } else {
-      val z = inputExpressions(2).eval(inputRow) match {
-        case a: Double => a
-        case b: Decimal => b.toDouble
-      }
-      new Coordinate(x, y, z)
-    }
-
-    var geometryFactory = new GeometryFactory()
-    var geometry = geometryFactory.createPoint(coord)
+    val geometryFactory = new GeometryFactory()
+    val geometry = geometryFactory.createPoint(coord)
     new GenericArrayData(GeometrySerializer.serialize(geometry))
   }
 
   override def dataType: DataType = GeometryUDT
+
+  override def inputTypes: Seq[AbstractDataType] = Seq(DoubleType, DoubleType, DoubleType)
 
   override def children: Seq[Expression] = inputExpressions
 
@@ -354,32 +362,16 @@ case class ST_Point(inputExpressions: Seq[Expression])
   * @param inputExpressions
   */
 case class ST_PolygonFromEnvelope(inputExpressions: Seq[Expression])
-  extends Expression with CodegenFallback with UserDataGeneratator {
+  extends Expression with FoldableExpression with ImplicitCastInputTypes with CodegenFallback with UserDataGeneratator {
   assert(inputExpressions.length == 4)
 
   override def nullable: Boolean = false
 
   override def eval(input: InternalRow): Any = {
-    val minX = inputExpressions(0).eval(input) match {
-      case a: Double => a
-      case b: Decimal => b.toDouble
-    }
-
-    val minY = inputExpressions(1).eval(input) match {
-      case a: Double => a
-      case b: Decimal => b.toDouble
-    }
-
-    val maxX = inputExpressions(2).eval(input) match {
-      case a: Double => a
-      case b: Decimal => b.toDouble
-    }
-
-    val maxY = inputExpressions(3).eval(input) match {
-      case a: Double => a
-      case b: Decimal => b.toDouble
-    }
-
+    val minX = inputExpressions(0).eval(input).asInstanceOf[Double]
+    val minY = inputExpressions(1).eval(input).asInstanceOf[Double]
+    val maxX = inputExpressions(2).eval(input).asInstanceOf[Double]
+    val maxY = inputExpressions(3).eval(input).asInstanceOf[Double]
     var coordinates = new Array[Coordinate](5)
     coordinates(0) = new Coordinate(minX, minY)
     coordinates(1) = new Coordinate(minX, maxY)
@@ -392,6 +384,8 @@ case class ST_PolygonFromEnvelope(inputExpressions: Seq[Expression])
   }
 
   override def dataType: DataType = GeometryUDT
+
+  override def inputTypes: Seq[AbstractDataType] = Seq(DoubleType, DoubleType, DoubleType, DoubleType)
 
   override def children: Seq[Expression] = inputExpressions
 
@@ -413,21 +407,19 @@ trait UserDataGeneratator {
 
 
 case class ST_GeomFromGeoHash(inputExpressions: Seq[Expression])
-  extends Expression with CodegenFallback {
-  assert(inputExpressions.length >= 1 && inputExpressions.length <= 2)
+  extends Expression with FoldableExpression with ImplicitCastInputTypes with CodegenFallback {
   override def nullable: Boolean = true
 
   override def eval(input: InternalRow): Any = {
     val geoHash = Option(inputExpressions.head.eval(input))
       .map(_.asInstanceOf[UTF8String].toString)
-    val precision = inputExpressions.tail.headOption.map(_.toInt(input))
+    val precision = Option(inputExpressions(1).eval(input)).map(_.asInstanceOf[Int])
 
     try {
       geoHash match {
         case Some(value) => GeoHashDecoder.decode(value, precision).toGenericArrayData
         case None => null
       }
-
     }
     catch {
       case e: Exception => null
@@ -435,6 +427,8 @@ case class ST_GeomFromGeoHash(inputExpressions: Seq[Expression])
   }
 
   override def dataType: DataType = GeometryUDT
+
+  override def inputTypes: Seq[AbstractDataType] = Seq(StringType, IntegerType)
 
   override def children: Seq[Expression] = inputExpressions
 
@@ -444,7 +438,7 @@ case class ST_GeomFromGeoHash(inputExpressions: Seq[Expression])
 }
 
 case class ST_GeomFromGML(inputExpressions: Seq[Expression])
-  extends Expression with CodegenFallback {
+  extends Expression with FoldableExpression with ImplicitCastInputTypes with CodegenFallback {
   assert(inputExpressions.length == 1)
   override def nullable: Boolean = true
 
@@ -458,6 +452,8 @@ case class ST_GeomFromGML(inputExpressions: Seq[Expression])
 
   override def dataType: DataType = GeometryUDT
 
+  override def inputTypes: Seq[AbstractDataType] = Seq(StringType)
+
   override def children: Seq[Expression] = inputExpressions
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -466,12 +462,12 @@ case class ST_GeomFromGML(inputExpressions: Seq[Expression])
 }
 
 case class ST_GeomFromKML(inputExpressions: Seq[Expression])
-  extends Expression with CodegenFallback {
+  extends Expression with FoldableExpression with ImplicitCastInputTypes with CodegenFallback {
   assert(inputExpressions.length == 1)
   override def nullable: Boolean = true
 
   override def eval(inputRow: InternalRow): Any = {
-    (inputExpressions(0).eval(inputRow)) match {
+    inputExpressions(0).eval(inputRow) match {
       case geomString: UTF8String =>
         new KMLReader().read(geomString.toString).toGenericArrayData
       case _ => null
@@ -479,6 +475,8 @@ case class ST_GeomFromKML(inputExpressions: Seq[Expression])
   }
 
   override def dataType: DataType = GeometryUDT
+
+  override def inputTypes: Seq[AbstractDataType] = Seq(StringType)
 
   override def children: Seq[Expression] = inputExpressions
 

--- a/sql/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/DataFrameAPI.scala
+++ b/sql/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/DataFrameAPI.scala
@@ -20,13 +20,10 @@ package org.apache.spark.sql.sedona_sql.expressions
 
 import scala.reflect.ClassTag
 
-import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder
 import org.apache.spark.sql.catalyst.expressions.{Expression, Literal}
 import org.apache.spark.sql.Column
 import org.apache.spark.sql.expressions.UserDefinedAggregateFunction
 import org.apache.spark.sql.execution.aggregate.ScalaUDAF
-import org.apache.spark.sql.functions.{lit, array}
-import org.locationtech.jts.geom.Geometry
 
 trait DataFrameAPI {
   protected def wrapExpression[E <: Expression : ClassTag](args: Any *): Column = {
@@ -35,6 +32,7 @@ trait DataFrameAPI {
       case s: String => Column(s).expr
       case e: Expression => e
       case x: Any => Literal(x)
+      case null => Literal(null)
     })
     val expressionConstructor = implicitly[ClassTag[E]].runtimeClass.getConstructor(classOf[Seq[Expression]])
     val expressionInstance = expressionConstructor.newInstance(exprArgs).asInstanceOf[E]
@@ -47,6 +45,7 @@ trait DataFrameAPI {
       case s: String => Column(s).expr
       case e: Expression => e
       case x: Any => Literal(x)
+      case null => Literal(null)
     })
     val expressionConstructor = implicitly[ClassTag[E]].runtimeClass.getConstructor(classOf[Seq[Expression]])
     val expressionInstance = expressionConstructor.newInstance(exprArgs).asInstanceOf[E]
@@ -59,6 +58,7 @@ trait DataFrameAPI {
       case s: String => Column(s).expr
       case e: Expression => e
       case x: Any => Literal(x)
+      case null => Literal(null)
     })
     val aggregatorClass = implicitly[ClassTag[A]].runtimeClass
     val aggregatorConstructor = aggregatorClass.getConstructor()

--- a/sql/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/collect/Collect.scala
+++ b/sql/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/collect/Collect.scala
@@ -39,7 +39,7 @@ object Collect {
     }
   }
 
-  private def createMultiGeometryFromOneElement(geom: Geometry): Geometry = {
+  def createMultiGeometryFromOneElement(geom: Geometry): Geometry = {
     geom match {
       case circle: Circle                 => geomFactory.createGeometryCollection(Array(circle))
       case collection: GeometryCollection => collection

--- a/sql/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/st_constructors.scala
+++ b/sql/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/st_constructors.scala
@@ -49,9 +49,9 @@ object st_constructors extends DataFrameAPI {
   def ST_LineStringFromText(coords: Column, delimiter: Column): Column = wrapExpression[ST_LineStringFromText](coords, delimiter)
   def ST_LineStringFromText(coords: String, delimiter: String): Column = wrapExpression[ST_LineStringFromText](coords, delimiter)
 
-  def ST_Point(x: Column, y: Column): Column = wrapExpression[ST_Point](x, y)
-  def ST_Point(x: String, y: String): Column = wrapExpression[ST_Point](x, y)
-  def ST_Point(x: Double, y: Double): Column = wrapExpression[ST_Point](x, y)
+  def ST_Point(x: Column, y: Column): Column = wrapExpression[ST_Point](x, y, null)
+  def ST_Point(x: String, y: String): Column = wrapExpression[ST_Point](x, y, null)
+  def ST_Point(x: Double, y: Double): Column = wrapExpression[ST_Point](x, y, null)
   def ST_Point(x: Column, y: Column, z: Column): Column = wrapExpression[ST_Point](x, y, z)
   def ST_Point(x: String, y: String, z: String): Column = wrapExpression[ST_Point](x, y, z)
   def ST_Point(x: Double, y: Double, z: Double): Column = wrapExpression[ST_Point](x, y, z)

--- a/sql/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/st_functions.scala
+++ b/sql/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/st_functions.scala
@@ -18,16 +18,16 @@
  */
 package org.apache.spark.sql.sedona_sql.expressions
 
-import org.apache.spark.sql.catalyst.expressions.Expression
 import org.apache.spark.sql.Column
 import org.apache.spark.sql.sedona_sql.expressions.collect.{ST_Collect, ST_CollectionExtract}
+import org.locationtech.jts.operation.buffer.BufferParameters
 
 object st_functions extends DataFrameAPI {
   def ST_3DDistance(a: Column, b: Column): Column = wrapExpression[ST_3DDistance](a, b)
   def ST_3DDistance(a: String, b: String): Column = wrapExpression[ST_3DDistance](a, b)
 
-  def ST_AddPoint(lineString: Column, point: Column): Column = wrapExpression[ST_AddPoint](lineString, point)
-  def ST_AddPoint(lineString: String, point: String): Column = wrapExpression[ST_AddPoint](lineString, point)
+  def ST_AddPoint(lineString: Column, point: Column): Column = wrapExpression[ST_AddPoint](lineString, point, -1)
+  def ST_AddPoint(lineString: String, point: String): Column = wrapExpression[ST_AddPoint](lineString, point, -1)
   def ST_AddPoint(lineString: Column, point: Column, index: Column): Column = wrapExpression[ST_AddPoint](lineString, point, index)
   def ST_AddPoint(lineString: String, point: String, index: Int): Column = wrapExpression[ST_AddPoint](lineString, point, index)
 
@@ -159,15 +159,15 @@ object st_functions extends DataFrameAPI {
   def ST_MakePolygon(lineString: Column, holes: Column): Column = wrapExpression[ST_MakePolygon](lineString, holes)
   def ST_MakePolygon(lineString: String, holes: String): Column = wrapExpression[ST_MakePolygon](lineString, holes)
 
-  def ST_MakeValid(geometry: Column): Column = wrapExpression[ST_MakeValid](geometry)
-  def ST_MakeValid(geometry: String): Column = wrapExpression[ST_MakeValid](geometry)
+  def ST_MakeValid(geometry: Column): Column = wrapExpression[ST_MakeValid](geometry, false)
+  def ST_MakeValid(geometry: String): Column = wrapExpression[ST_MakeValid](geometry, false)
   def ST_MakeValid(geometry: Column, keepCollapsed: Column): Column = wrapExpression[ST_MakeValid](geometry, keepCollapsed)
   def ST_MakeValid(geometry: String, keepCollapsed: Boolean): Column = wrapExpression[ST_MakeValid](geometry, keepCollapsed)
 
-  def ST_MinimumBoundingCircle(geometry: Column): Column = wrapExpression[ST_MinimumBoundingCircle](geometry)
-  def ST_MinimumBoundingCircle(geometry: String): Column = wrapExpression[ST_MinimumBoundingCircle](geometry)
-  def ST_MinimumBoundingCircle(geometry: Column, quadrantSegments: Column): Column = wrapExpression[ST_MinimumBoundingCircle](geometry)
-  def ST_MinimumBoundingCircle(geometry: String, quadrantSegments: Int): Column = wrapExpression[ST_MinimumBoundingCircle](geometry)
+  def ST_MinimumBoundingCircle(geometry: Column): Column = wrapExpression[ST_MinimumBoundingCircle](geometry, BufferParameters.DEFAULT_QUADRANT_SEGMENTS)
+  def ST_MinimumBoundingCircle(geometry: String): Column = wrapExpression[ST_MinimumBoundingCircle](geometry, BufferParameters.DEFAULT_QUADRANT_SEGMENTS)
+  def ST_MinimumBoundingCircle(geometry: Column, quadrantSegments: Column): Column = wrapExpression[ST_MinimumBoundingCircle](geometry, quadrantSegments)
+  def ST_MinimumBoundingCircle(geometry: String, quadrantSegments: Int): Column = wrapExpression[ST_MinimumBoundingCircle](geometry, quadrantSegments)
 
   def ST_MinimumBoundingRadius(geometry: Column): Column = wrapExpression[ST_MinimumBoundingRadius](geometry)
   def ST_MinimumBoundingRadius(geometry: String): Column = wrapExpression[ST_MinimumBoundingRadius](geometry)
@@ -226,8 +226,8 @@ object st_functions extends DataFrameAPI {
   def ST_SymDifference(a: Column, b: Column): Column = wrapExpression[ST_SymDifference](a, b)
   def ST_SymDifference(a: String, b: String): Column = wrapExpression[ST_SymDifference](a, b)
 
-  def ST_Transform(geometry: Column, sourceCRS: Column, targetCRS: Column): Column = wrapExpression[ST_Transform](geometry, sourceCRS, targetCRS)
-  def ST_Transform(geometry: String, sourceCRS: String, targetCRS: String): Column = wrapExpression[ST_Transform](geometry, sourceCRS, targetCRS)
+  def ST_Transform(geometry: Column, sourceCRS: Column, targetCRS: Column): Column = wrapExpression[ST_Transform](geometry, sourceCRS, targetCRS, false)
+  def ST_Transform(geometry: String, sourceCRS: String, targetCRS: String): Column = wrapExpression[ST_Transform](geometry, sourceCRS, targetCRS, false)
   def ST_Transform(geometry: Column, sourceCRS: Column, targetCRS: Column, disableError: Column): Column = wrapExpression[ST_Transform](geometry, sourceCRS, targetCRS, disableError)
   def ST_Transform(geometry: String, sourceCRS: String, targetCRS: String, disableError: Boolean): Column = wrapExpression[ST_Transform](geometry, sourceCRS, targetCRS, disableError)
   

--- a/sql/src/test/scala/org/apache/sedona/sql/dataFrameAPITestScala.scala
+++ b/sql/src/test/scala/org/apache/sedona/sql/dataFrameAPITestScala.scala
@@ -598,7 +598,7 @@ class dataFrameAPITestScala extends TestBaseScala {
       val baseDf = sparkSession.sql("SELECT ST_GeomFromWKT('LINESTRING (0 0, 1 0)') AS geom")
       val df = baseDf.select(ST_MinimumBoundingCircle("geom", 2).as("geom")).selectExpr("ST_PrecisionReduce(geom, 2)")
       val actualResult = df.take(1)(0).get(0).asInstanceOf[Geometry].toText()
-      val expectedResult = "POLYGON ((0.99 -0.1, 0.96 -0.19, 0.92 -0.28, 0.85 -0.35, 0.78 -0.42, 0.69 -0.46, 0.6 -0.49, 0.5 -0.5, 0.4 -0.49, 0.31 -0.46, 0.22 -0.42, 0.15 -0.35, 0.08 -0.28, 0.04 -0.19, 0.01 -0.1, 0 0, 0.01 0.1, 0.04 0.19, 0.08 0.28, 0.15 0.35, 0.22 0.42, 0.31 0.46, 0.4 0.49, 0.5 0.5, 0.6 0.49, 0.69 0.46, 0.78 0.42, 0.85 0.35, 0.92 0.28, 0.96 0.19, 0.99 0.1, 1 0, 0.99 -0.1))"
+      val expectedResult = "POLYGON ((0.85 -0.35, 0.5 -0.5, 0.15 -0.35, 0 0, 0.15 0.35, 0.5 0.5, 0.85 0.35, 1 0, 0.85 -0.35))"
       assert(actualResult == expectedResult)
     }
 


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read [Contributor Rules](https://sedona.apache.org/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/community/develop/)

## Is this PR related to a JIRA ticket?

- Yes, the URL of the assoicated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-180.

## What changes were proposed in this PR?

This patch makes ST_* functions foldable, and declared input types for these functions to make the SQL analyzer perform type checking for these ST_* function calls and emit more friendly error messages. Raster functions and viz functions are still left unchanged.

I've deliberately left `ST_Binary` and `ST_AsEWKB` unfoldable since unit tests would fail after making these expressions foldable.
The reason is that folding binary expressions as constants triggers a function call to [`encodeHexString(byte[], boolean)`](https://commons.apache.org/proper/commons-codec/apidocs/org/apache/commons/codec/binary/Hex.html#encodeHexString-byte:A-boolean-) in spark-sql, while the bundled Apache commons-codec of sernetcdf jar do not have this function defined. We may have to release a new version of sernetcdf with a newer version of / without commons-codec bundled.

I've also moved some implementations of ST functions to `sedona-common`, so that they can be reused by other distributed computation engines.

I also spotted a bug in `ST_MinimumBoundingCircle` dataframe API, it does not honor the second parameter. This patch also includes a fix for that bug.

## How was this patch tested?

Hopefully existing unit tests are sufficient to guarantee that I'm not breaking anything.

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the docs.
