### PR TITLE
[SEDONA-183] Python version check fails when Sedona JAR is distributed by YARN

### DIFF
--- a/python/tests/core/test_config.py
+++ b/python/tests/core/test_config.py
@@ -1,0 +1,33 @@
+import os
+
+from sedona.core.jvm.config import SparkJars, SedonaMeta
+from tests.test_base import TestBase
+
+
+class TestCoreJVMConfig(TestBase):
+    def test_yarn_jars(self):
+
+        used_jar_files = ",".join(
+            os.listdir(os.path.join(os.environ["SPARK_HOME"], "jars"))
+        )
+
+        # Test's don't run on YARN but can set the property manually to confirm
+        # the python checks work
+        self.spark.conf.set("spark.yarn.dist.jars", used_jar_files)
+
+        assert "sedona" in SparkJars().jars
+
+        self.spark.conf.unset("spark.yarn.dist.jars")
+
+    def test_sedona_version(self):
+        used_jar_files = ",".join(
+            os.listdir(os.path.join(os.environ["SPARK_HOME"], "jars"))
+        )
+
+        # Test's don't run on YARN but can set the property manually to confirm
+        # the python checks work
+        self.spark.conf.set("spark.yarn.dist.jars", used_jar_files)
+
+        assert SedonaMeta().version is not None
+
+        self.spark.conf.unset("spark.yarn.dist.jars")


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read [Contributor Rules](https://sedona.apache.org/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/community/develop/)

## What changes were proposed in this PR?

When Sedona is deployed via YARN the version check fails due to the jars being listed under `spark.yarn.dist.jars` instead of `spark.jars`. 

## How was this patch tested?

- Added a unit test to mock the behaviour
- Tested that Sedona is listed in `spark.yarn.dist.jars` on a YARN deployment

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the docs.
