### PR TITLE
[SEDONA-186] Fix ordering of columns in results of queries like SELECT * A JOIN B

### DIFF
--- a/sql/src/main/scala/org/apache/spark/sql/sedona_sql/strategy/join/DistanceJoinExec.scala
+++ b/sql/src/main/scala/org/apache/spark/sql/sedona_sql/strategy/join/DistanceJoinExec.scala
@@ -38,18 +38,20 @@ import org.locationtech.jts.geom.Geometry
  *
  * select * from a join b on ST_Intersects(ST_Envelope(ST_Buffer(a.geom, 1)), b.geom) and ST_Distance(a.geom, b.geom) <= 1
  *
- * @param left
- * @param right
- * @param leftShape
- * @param rightShape
+ * @param left left side of the join
+ * @param right right side of the join
+ * @param leftShape expression for the first argument of spatialPredicate
+ * @param rightShape expression for the second argument of spatialPredicate
+ * @param swappedLeftAndRight boolean indicating whether left and right plans were swapped
  * @param distance - ST_Distance(left, right) <= distance. Distance can be literal or a computation over 'left'.
- * @param spatialPredicate
- * @param extraCondition
+ * @param spatialPredicate spatial predicate as join condition
+ * @param extraCondition extra join condition other than spatialPredicate
  */
 case class DistanceJoinExec(left: SparkPlan,
                             right: SparkPlan,
                             leftShape: Expression,
                             rightShape: Expression,
+                            swappedLeftAndRight: Boolean,
                             distance: Expression,
                             spatialPredicate: SpatialPredicate,
                             extraCondition: Option[Expression] = None)

--- a/sql/src/main/scala/org/apache/spark/sql/sedona_sql/strategy/join/JoinQueryDetector.scala
+++ b/sql/src/main/scala/org/apache/spark/sql/sedona_sql/strategy/join/JoinQueryDetector.scala
@@ -164,9 +164,9 @@ class JoinQueryDetector(sparkSession: SparkSession) extends Strategy {
     val relationship = s"ST_$spatialPredicate"
 
     matchExpressionsToPlans(a, b, left, right) match {
-      case Some((planA, planB, _)) =>
+      case Some((planA, planB, swappedLeftAndRight)) =>
         logInfo(s"Planning spatial join for $relationship relationship")
-        RangeJoinExec(planLater(planA), planLater(planB), a, b, spatialPredicate, extraCondition) :: Nil
+        RangeJoinExec(planLater(planA), planLater(planB), a, b, swappedLeftAndRight, spatialPredicate, extraCondition) :: Nil
       case None =>
         logInfo(
           s"Spatial join for $relationship with arguments not aligned " +
@@ -185,13 +185,13 @@ class JoinQueryDetector(sparkSession: SparkSession) extends Strategy {
     val b = children.tail.head
 
     matchExpressionsToPlans(a, b, left, right) match {
-      case Some((planA, planB, _)) =>
+      case Some((planA, planB, swappedLeftAndRight)) =>
         if (distance.references.isEmpty || matches(distance, planA)) {
           logInfo("Planning spatial distance join")
-          DistanceJoinExec(planLater(planA), planLater(planB), a, b, distance, spatialPredicate, extraCondition) :: Nil
+          DistanceJoinExec(planLater(planA), planLater(planB), a, b, swappedLeftAndRight, distance, spatialPredicate, extraCondition) :: Nil
         } else if (matches(distance, planB)) {
           logInfo("Planning spatial distance join")
-          DistanceJoinExec(planLater(planB), planLater(planA), b, a, distance, spatialPredicate, extraCondition) :: Nil
+          DistanceJoinExec(planLater(planB), planLater(planA), b, a, swappedLeftAndRight, distance, spatialPredicate, extraCondition) :: Nil
         } else {
           logInfo(
             "Spatial distance join for ST_Distance with non-scalar distance " +

--- a/sql/src/main/scala/org/apache/spark/sql/sedona_sql/strategy/join/RangeJoinExec.scala
+++ b/sql/src/main/scala/org/apache/spark/sql/sedona_sql/strategy/join/RangeJoinExec.scala
@@ -31,15 +31,17 @@ import org.apache.spark.sql.sedona_sql.execution.SedonaBinaryExecNode
   *
   * @param left       left side of the join
   * @param right      right side of the join
-  * @param leftShape  expression for the first argument of ST_Contains or ST_Intersects
-  * @param rightShape expression for the second argument of ST_Contains or ST_Intersects
-  * @param intersects boolean indicating whether spatial relationship is 'intersects' (true)
-  *                   or 'contains' (false)
+  * @param leftShape  expression for the first argument of spatialPredicate
+  * @param rightShape expression for the second argument of spatialPredicate
+  * @param swappedLeftAndRight boolean indicating whether left and right plans were swapped
+  * @param spatialPredicate spatial predicate as join condition
+  * @param extraCondition extra join condition other than spatialPredicate
   */
 case class RangeJoinExec(left: SparkPlan,
                          right: SparkPlan,
                          leftShape: Expression,
                          rightShape: Expression,
+                         swappedLeftAndRight: Boolean,
                          spatialPredicate: SpatialPredicate,
                          extraCondition: Option[Expression] = None)
   extends SedonaBinaryExecNode


### PR DESCRIPTION

## Did you read the Contributor Guide?

- Yes, I have read [Contributor Rules](https://sedona.apache.org/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/community/develop/)

## Is this PR related to a JIRA ticket?

- Yes, the URL of the assoicated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-186

## What changes were proposed in this PR?

Fixes [SEDONA-186](https://issues.apache.org/jira/browse/SEDONA-186) by properly assembling result rows of join queries when left and right sub plans were swapped.

## How was this patch tested?

New tests were added to `SpatialJoinSuite`.

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the docs.
