### PR TITLE
[SEDONA-189] Prepare geometries in broadcast join

### DIFF
--- a/core/src/main/java/org/apache/sedona/core/spatialOperator/SpatialPredicateEvaluators.java
+++ b/core/src/main/java/org/apache/sedona/core/spatialOperator/SpatialPredicateEvaluators.java
@@ -20,6 +20,7 @@
 package org.apache.sedona.core.spatialOperator;
 
 import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.prep.PreparedGeometry;
 
 import java.io.Serializable;
 
@@ -32,10 +33,16 @@ public class SpatialPredicateEvaluators {
      */
     public interface SpatialPredicateEvaluator extends Serializable {
         boolean eval(Geometry left, Geometry right);
+
+        boolean eval(PreparedGeometry left, Geometry right);
     }
 
     public interface ContainsEvaluator extends SpatialPredicateEvaluator {
         default boolean eval(Geometry left, Geometry right) {
+            return left.contains(right);
+        }
+
+        default boolean eval(PreparedGeometry left, Geometry right) {
             return left.contains(right);
         }
     }
@@ -44,16 +51,29 @@ public class SpatialPredicateEvaluators {
         default boolean eval(Geometry left, Geometry right) {
             return left.intersects(right);
         }
+
+        default boolean eval(PreparedGeometry left, Geometry right) {
+            return left.intersects(right);
+        }
     }
 
     public interface WithinEvaluator extends SpatialPredicateEvaluator {
         default boolean eval(Geometry left, Geometry right) {
             return left.within(right);
         }
+
+        default boolean eval(PreparedGeometry left, Geometry right) {
+            return left.within(right);
+        }
+
     }
 
     public interface CoversEvaluator extends SpatialPredicateEvaluator {
         default boolean eval(Geometry left, Geometry right) {
+            return left.covers(right);
+        }
+
+        default boolean eval(PreparedGeometry left, Geometry right) {
             return left.covers(right);
         }
     }
@@ -62,10 +82,18 @@ public class SpatialPredicateEvaluators {
         default boolean eval(Geometry left, Geometry right) {
             return left.coveredBy(right);
         }
+
+        default boolean eval(PreparedGeometry left, Geometry right) {
+            return left.coveredBy(right);
+        }
     }
 
     public interface TouchesEvaluator extends SpatialPredicateEvaluator {
         default boolean eval(Geometry left, Geometry right) {
+            return left.touches(right);
+        }
+
+        default boolean eval(PreparedGeometry left, Geometry right) {
             return left.touches(right);
         }
     }
@@ -74,10 +102,18 @@ public class SpatialPredicateEvaluators {
         default boolean eval(Geometry left, Geometry right) {
             return left.overlaps(right);
         }
+
+        default boolean eval(PreparedGeometry left, Geometry right) {
+            return left.overlaps(right);
+        }
     }
 
     public interface CrossesEvaluator extends SpatialPredicateEvaluator {
         default boolean eval(Geometry left, Geometry right) {
+            return left.crosses(right);
+        }
+
+        default boolean eval(PreparedGeometry left, Geometry right) {
             return left.crosses(right);
         }
     }
@@ -85,6 +121,10 @@ public class SpatialPredicateEvaluators {
     public interface EqualsEvaluator extends SpatialPredicateEvaluator {
         default boolean eval(Geometry left, Geometry right) {
             return left.symDifference(right).isEmpty();
+        }
+
+        default boolean eval(PreparedGeometry left, Geometry right) {
+            return left.getGeometry().symDifference(right).isEmpty();
         }
     }
 


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read [Contributor Rules](https://sedona.apache.org/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/community/develop/)

## Is this PR related to a JIRA ticket?

- Yes, the URL of the assoicated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-189. The PR name follows the format `[SEDONA-189] my subject`.

## What changes were proposed in this PR?
Use prepared geometries in `BroadcastIndexJoinExec` to speed up queries. In jira there is a simple dataset of polygons and points, where the speedup is around 4x.

Preparing the geometry has some overhead, but it will be compensated if the prepared geometry will be used several times. Using it in broadcast join seems like a safe bet - the broadcasted dataset is meant to be small.

## How was this patch tested?
Running the existing UTs in sql submodule

## Did this PR include necessary documentation updates?
- No, this PR does not affect any public API so no need to change the docs.
