### PR TITLE
[SEDONA-192] Null handling in predicates

### DIFF
--- a/sql/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/Predicates.scala
+++ b/sql/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/Predicates.scala
@@ -20,22 +20,24 @@ package org.apache.spark.sql.sedona_sql.expressions
 
 import org.apache.sedona.sql.utils.GeometrySerializer
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.catalyst.expressions.Expression
+import org.apache.spark.sql.catalyst.expressions.{ExpectsInputTypes, Expression, NullIntolerant}
 import org.apache.spark.sql.catalyst.expressions.codegen.CodegenFallback
 import org.apache.spark.sql.catalyst.util.ArrayData
 import org.apache.spark.sql.types.{BooleanType, DataType}
 import org.locationtech.jts.geom.Geometry
-import org.apache.spark.sql.catalyst.expressions.ExpectsInputTypes
 import org.apache.spark.sql.types.AbstractDataType
 import org.apache.spark.sql.sedona_sql.UDT.GeometryUDT
 
-abstract class ST_Predicate extends Expression with FoldableExpression with ExpectsInputTypes {
+abstract class ST_Predicate extends Expression
+  with FoldableExpression
+  with ExpectsInputTypes
+  with NullIntolerant {
 
   def inputExpressions: Seq[Expression]
 
   override def toString: String = s" **${this.getClass.getName}**  "
 
-  override def nullable: Boolean = false
+  override def nullable: Boolean = children.exists(_.nullable)
 
   override def inputTypes: Seq[AbstractDataType] = Seq(GeometryUDT, GeometryUDT)
 
@@ -46,9 +48,13 @@ abstract class ST_Predicate extends Expression with FoldableExpression with Expe
   override def eval(inputRow: InternalRow): Any = {
     val leftArray = inputExpressions(0).eval(inputRow).asInstanceOf[ArrayData]
     val rightArray = inputExpressions(1).eval(inputRow).asInstanceOf[ArrayData]
-    val leftGeometry = GeometrySerializer.deserialize(leftArray)
-    val rightGeometry = GeometrySerializer.deserialize(rightArray)
-    evalGeom(leftGeometry, rightGeometry)
+    if (leftArray == null || rightArray == null) {
+      null
+    } else {
+      val leftGeometry = GeometrySerializer.deserialize(leftArray)
+      val rightGeometry = GeometrySerializer.deserialize(rightArray)
+      evalGeom(leftGeometry, rightGeometry)
+    }
   }
 
   def evalGeom(leftGeometry: Geometry, rightGeometry: Geometry): Boolean

--- a/sql/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/Predicates.scala
+++ b/sql/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/Predicates.scala
@@ -45,7 +45,7 @@ abstract class ST_Predicate extends Expression
 
   override def children: Seq[Expression] = inputExpressions
 
-  override def eval(inputRow: InternalRow): Any = {
+  override final def eval(inputRow: InternalRow): Any = {
     val leftArray = inputExpressions(0).eval(inputRow).asInstanceOf[ArrayData]
     if (leftArray == null) {
       null

--- a/sql/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/Predicates.scala
+++ b/sql/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/Predicates.scala
@@ -47,13 +47,17 @@ abstract class ST_Predicate extends Expression
 
   override def eval(inputRow: InternalRow): Any = {
     val leftArray = inputExpressions(0).eval(inputRow).asInstanceOf[ArrayData]
-    val rightArray = inputExpressions(1).eval(inputRow).asInstanceOf[ArrayData]
-    if (leftArray == null || rightArray == null) {
+    if (leftArray == null) {
       null
     } else {
-      val leftGeometry = GeometrySerializer.deserialize(leftArray)
-      val rightGeometry = GeometrySerializer.deserialize(rightArray)
-      evalGeom(leftGeometry, rightGeometry)
+      val rightArray = inputExpressions(1).eval(inputRow).asInstanceOf[ArrayData]
+      if (rightArray == null) {
+        null
+      } else {
+        val leftGeometry = GeometrySerializer.deserialize(leftArray)
+        val rightGeometry = GeometrySerializer.deserialize(rightArray)
+        evalGeom(leftGeometry, rightGeometry)
+      }
     }
   }
 

--- a/sql/src/test/scala/org/apache/sedona/sql/predicateTestScala.scala
+++ b/sql/src/test/scala/org/apache/sedona/sql/predicateTestScala.scala
@@ -19,6 +19,9 @@
 
 package org.apache.sedona.sql
 
+import org.apache.spark.sql.catalyst.expressions.{EmptyRow, Literal}
+import org.apache.spark.sql.sedona_sql.expressions.{ST_Contains, ST_CoveredBy, ST_Covers, ST_Crosses, ST_Disjoint, ST_Equals, ST_Intersects, ST_OrderingEquals, ST_Overlaps, ST_Point, ST_Touches, ST_Within}
+
 class predicateTestScala extends TestBaseScala {
 
   describe("Sedona-SQL Predicate Test") {
@@ -244,6 +247,20 @@ class predicateTestScala extends TestBaseScala {
       val coveredBy = sparkSession.sql("select ST_CoveredBy(b, a) from testtable").take(1)(0)
       assert(!within.get(0).asInstanceOf[Boolean])
       assert(coveredBy.get(0).asInstanceOf[Boolean])
+    }
+
+    Seq(
+      ST_Contains, ST_Intersects, ST_Within, ST_Covers, ST_CoveredBy, ST_Crosses,
+      ST_Overlaps, ST_Touches, ST_Equals, ST_Disjoint, ST_OrderingEquals
+    ).foreach { predicate =>
+      it(s"Passed null handling in $predicate") {
+        val point = ST_Point(Literal.create(0.0) :: Literal.create(0.0) :: Literal.create(0.0):: Nil)
+        val missing = Literal.create(null)
+
+        assert(predicate(point :: missing :: Nil).eval(EmptyRow) == null)
+        assert(predicate(missing :: point :: Nil).eval(EmptyRow) == null)
+        assert(predicate(missing :: missing :: Nil).eval(EmptyRow) == null)
+      }
     }
   }
 }

--- a/sql/src/test/scala/org/apache/sedona/sql/predicateTestScala.scala
+++ b/sql/src/test/scala/org/apache/sedona/sql/predicateTestScala.scala
@@ -257,6 +257,7 @@ class predicateTestScala extends TestBaseScala {
         val point = ST_Point(Literal.create(0.0) :: Literal.create(0.0) :: Literal.create(0.0):: Nil)
         val missing = Literal.create(null)
 
+        assert(predicate(point :: point :: Nil).eval(EmptyRow) != null)
         assert(predicate(point :: missing :: Nil).eval(EmptyRow) == null)
         assert(predicate(missing :: point :: Nil).eval(EmptyRow) == null)
         assert(predicate(missing :: missing :: Nil).eval(EmptyRow) == null)


### PR DESCRIPTION

## Did you read the Contributor Guide?

- Yes, I have read [Contributor Rules](https://sedona.apache.org/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/community/develop/)

## Is this PR related to a JIRA ticket?

- Yes, the URL of the assoicated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-192. The PR name follows the format `[SEDONA-XXX] my subject`.

## What changes were proposed in this PR?
Allow nulls in predicate inputs - currently they end with nullpointer exception. Also added the `org.apache.spark.sql.catalyst.expressions.NullIntolerant` trait to `ST_Predicate`, so catalyst optimizer can infer notnull filters on nullable inputs.

## How was this patch tested?
Unittests


## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the docs.
