### PR TITLE
[SEDONA-204] Change Double.MIN_Value to -Double.MAX_Value

### DIFF
--- a/common/src/main/java/org/apache/sedona/common/Functions.java
+++ b/common/src/main/java/org/apache/sedona/common/Functions.java
@@ -130,7 +130,7 @@ public class Functions {
     
     public static double xMax(Geometry geometry) {
         Coordinate[] points = geometry.getCoordinates();
-        double max = Double.MIN_VALUE;
+        double max = - Double.MAX_VALUE;
         for (int i=0; i < points.length; i++) {
             max = Math.max(points[i].getX(), max);
         }
@@ -148,7 +148,7 @@ public class Functions {
     
     public static double yMax(Geometry geometry) {
         Coordinate[] points = geometry.getCoordinates();
-        double max = Double.MIN_VALUE;
+        double max = - Double.MAX_VALUE;
         for (int i=0; i < points.length; i++) {
             max = Math.max(points[i].getY(), max);
         }
@@ -157,13 +157,13 @@ public class Functions {
 
     public static Double zMax(Geometry geometry) {
         Coordinate[] points = geometry.getCoordinates();
-        double max = Double.MIN_VALUE;
+        double max = - Double.MAX_VALUE;
         for (int i=0; i < points.length; i++) {
             if(java.lang.Double.isNaN(points[i].getZ()))
                 continue;
             max = Math.max(points[i].getZ(), max);
         }
-        return max == Double.MIN_VALUE ? null : max;
+        return max == -Double.MAX_VALUE ? null : max;
     }
 
     public static Double zMin(Geometry geometry) {

--- a/flink/src/main/java/org/apache/sedona/flink/expressions/Accumulators.java
+++ b/flink/src/main/java/org/apache/sedona/flink/expressions/Accumulators.java
@@ -24,13 +24,13 @@ public class Accumulators {
     public static class Envelope {
         public double minX = Double.MAX_VALUE;
         public double minY = Double.MAX_VALUE;
-        public double maxX = Double.MIN_VALUE;
-        public double maxY = Double.MIN_VALUE;
+        public double maxX = -Double.MAX_VALUE;
+        public double maxY = -Double.MAX_VALUE;
         void reset() {
             minX = Double.MAX_VALUE;
             minY = Double.MAX_VALUE;
-            maxX = Double.MIN_VALUE;
-            maxY = Double.MIN_VALUE;
+            maxX = -Double.MAX_VALUE;
+            maxY = -Double.MAX_VALUE;
         }
     }
     public static class AccGeometry {

--- a/sql/src/test/scala/org/apache/sedona/sql/functionTestScala.scala
+++ b/sql/src/test/scala/org/apache/sedona/sql/functionTestScala.scala
@@ -23,21 +23,19 @@ import org.apache.commons.codec.binary.Hex
 import org.apache.sedona.sql.implicits._
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.{DataFrame, Row}
+import org.geotools.referencing.CRS
 import org.locationtech.jts.algorithm.MinimumBoundingCircle
 import org.locationtech.jts.geom.{Geometry, Polygon}
 import org.locationtech.jts.io.WKTWriter
 import org.locationtech.jts.linearref.LengthIndexedLine
 import org.locationtech.jts.operation.distance3d.Distance3DOp
+import org.opengis.referencing.{FactoryException, NoSuchAuthorityCodeException}
 import org.scalatest.{GivenWhenThen, Matchers}
 import org.xml.sax.InputSource
-import java.io.StringReader
 
+import java.io.StringReader
 import javax.xml.parsers.DocumentBuilderFactory
 import javax.xml.xpath.XPathFactory
-import org.apache.sedona.sql.utils.GeometrySerializer
-import org.apache.spark.SparkException
-import org.geotools.referencing.CRS
-import org.opengis.referencing.{FactoryException, NoSuchAuthorityCodeException}
 
 class functionTestScala extends TestBaseScala with Matchers with GeometrySample with GivenWhenThen {
 
@@ -73,8 +71,8 @@ class functionTestScala extends TestBaseScala with Matchers with GeometrySample 
     }
 
     it("Passed ST_YMax") {
-      var test = sparkSession.sql("SELECT ST_YMax(ST_GeomFromWKT('POLYGON ((-3 -3, 3 -3, 3 3, -3 3, -3 -3))'))")
-      assert(test.take(1)(0).get(0).asInstanceOf[Double] == 3.0)
+      var test = sparkSession.sql("SELECT ST_YMax(ST_GeomFromWKT('POLYGON ((-3 -3, 3 -3, 3 -2, -3 -1, -3 -3))'))")
+      assert(test.take(1)(0).get(0).asInstanceOf[Double] == -1)
     }
 
     it("Passed ST_YMin") {


### PR DESCRIPTION

## Did you read the Contributor Guide?

- Yes, I have read [Contributor Rules](https://sedona.apache.org/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/community/develop/)


## Is this PR related to a JIRA ticket?

- Yes, the URL of the assoicated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-204. The PR name follows the format `[SEDONA-204] my subject`.


## What changes were proposed in this PR?

Change all `Double.MIN_VALUE` usage to `-Double.MAX_VALUE` because `Double.MIN_VALUE` returns a non-negative value while coordinates could be negative.


## How was this patch tested?

Pass existing unit tests and add a test for negative coordinates.

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the docs.
