### PR TITLE
[SEDONA-206] Performance regression of ST_Transform

### DIFF
--- a/common/src/main/java/org/apache/sedona/common/Functions.java
+++ b/common/src/main/java/org/apache/sedona/common/Functions.java
@@ -191,20 +191,20 @@ public class Functions {
         return JTS.transform(geometry, transform);
     }
 
-    private static CoordinateReferenceSystem parseCRSString(String CRSString) throws FactoryException {
+    private static CoordinateReferenceSystem parseCRSString(String CRSString)
+            throws FactoryException
+    {
         try {
-            return CRS.parseWKT(CRSString);
+            return CRS.decode(CRSString);
         }
-        catch (FactoryException ex1) {
+        catch (NoSuchAuthorityCodeException e) {
             try {
-                return CRS.decode(CRSString);
-            } catch (NoSuchAuthorityCodeException ex4) {
-                throw new NoSuchAuthorityCodeException("that Authority code cannot be found", CRSString, CRSString);
-            } catch (FactoryException ex6) {
-                throw new FactoryException("WKT format is illegal");
+                return CRS.parseWKT(CRSString);
+            }
+            catch (FactoryException ex) {
+                throw new FactoryException("First failed to read as a well-known CRS code: \n" + e.getMessage() + "\nThen failed to read as a WKT CRS string: \n" + ex.getMessage());
             }
         }
-
     }
 
     public static Geometry flipCoordinates(Geometry geometry) {

--- a/sql/src/test/scala/org/apache/sedona/sql/functionTestScala.scala
+++ b/sql/src/test/scala/org/apache/sedona/sql/functionTestScala.scala
@@ -23,21 +23,19 @@ import org.apache.commons.codec.binary.Hex
 import org.apache.sedona.sql.implicits._
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.{DataFrame, Row}
+import org.geotools.referencing.CRS
 import org.locationtech.jts.algorithm.MinimumBoundingCircle
 import org.locationtech.jts.geom.{Geometry, Polygon}
 import org.locationtech.jts.io.WKTWriter
 import org.locationtech.jts.linearref.LengthIndexedLine
 import org.locationtech.jts.operation.distance3d.Distance3DOp
+import org.opengis.referencing.FactoryException
 import org.scalatest.{GivenWhenThen, Matchers}
 import org.xml.sax.InputSource
-import java.io.StringReader
 
+import java.io.StringReader
 import javax.xml.parsers.DocumentBuilderFactory
 import javax.xml.xpath.XPathFactory
-import org.apache.sedona.sql.utils.GeometrySerializer
-import org.apache.spark.SparkException
-import org.geotools.referencing.CRS
-import org.opengis.referencing.{FactoryException, NoSuchAuthorityCodeException}
 
 class functionTestScala extends TestBaseScala with Matchers with GeometrySample with GivenWhenThen {
 
@@ -207,7 +205,7 @@ class functionTestScala extends TestBaseScala with Matchers with GeometrySample 
         val d = org.apache.sedona.common.Functions.transform(polygeom, epsgString, epsgFactoryErrorString)
       }
 
-      intercept[NoSuchAuthorityCodeException]{
+      intercept[FactoryException]{
         val d2 = org.apache.sedona.common.Functions.transform(polygeom, epsgString, epsgNoSuchAuthorityString)
       }
 


### PR DESCRIPTION

## Did you read the Contributor Guide?

- Yes, I have read [Contributor Rules](https://sedona.apache.org/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/community/develop/)

## Is this PR related to a JIRA ticket?

- Yes, the URL of the assoicated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-206. The PR name follows the format `[SEDONA-206] my subject`.


## What changes were proposed in this PR?

Swap CRS.decode and CRS.parseWKT in ST_Transform function. So the default becomes that first try CRS.decode then call CRS.parseWKT. This makes sense since in most cases, people just use an existing CRS code issues by an authority. This could significantly speed up ST_Transform

## How was this patch tested?

Passed unit tests

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the docs.
