### PR TITLE
[SEDONA-194] Merge org.datasyslab.sernetcdf into Sedona

### DIFF
--- a/core/src/main/java/org/apache/sedona/core/formatMapper/EarthdataHDFPointMapper.java
+++ b/core/src/main/java/org/apache/sedona/core/formatMapper/EarthdataHDFPointMapper.java
@@ -19,8 +19,8 @@
 
 package org.apache.sedona.core.formatMapper;
 
+import org.apache.sedona.core.formatMapper.netcdfParser.SerNetCDFUtils;
 import org.apache.spark.api.java.function.FlatMapFunction;
-import org.datasyslab.sernetcdf.SerNetCDFUtils;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.GeometryFactory;

--- a/core/src/main/java/org/apache/sedona/core/formatMapper/netcdfParser/HDFSRandomAccessFile.java
+++ b/core/src/main/java/org/apache/sedona/core/formatMapper/netcdfParser/HDFSRandomAccessFile.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * The following content is directly copied from SciSpark project which is under Apache License.
+ * SciSpark project is hosted on GitHub: https://github.com/SciSpark/SciSpark
+ */
+package org.apache.sedona.core.formatMapper.netcdfParser;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import ucar.unidata.io.RandomAccessFile;
+
+import java.io.IOException;
+import java.net.URI;
+import java.nio.ByteBuffer;
+import java.nio.channels.WritableByteChannel;
+
+public class HDFSRandomAccessFile
+        extends RandomAccessFile
+{
+
+    protected URI fsURI;
+    protected Path filePath;
+    protected FSDataInputStream hfile;
+    protected FileStatus fileStatus;
+
+    public HDFSRandomAccessFile(String fileSystemURI, String location)
+            throws IOException
+    {
+        this(fileSystemURI, location, defaultBufferSize);
+    }
+
+    public HDFSRandomAccessFile(String fileSystemURI, String location, int bufferSize)
+            throws IOException
+    {
+        super(bufferSize);
+        fsURI = URI.create(fileSystemURI);
+        filePath = new Path(location);
+        this.location = location;
+        if (debugLeaks) {
+            openFiles.add(location);
+        }
+
+        FileSystem fs = FileSystem.get(fsURI, new Configuration());
+        hfile = fs.open(filePath);
+
+        fileStatus = fs.getFileStatus(filePath);
+    }
+
+    @Override
+    public void flush()
+    {
+
+    }
+
+    @Override
+    public synchronized void close()
+            throws IOException
+    {
+        super.close();
+        hfile.close();
+    }
+
+    public long getLastModified()
+    {
+        return fileStatus.getModificationTime();
+    }
+
+    @Override
+    public long length()
+            throws IOException
+    {
+        return fileStatus.getLen();
+    }
+
+    @Override
+    protected int read_(long pos, byte[] b, int offset, int len)
+            throws IOException
+    {
+        int n = hfile.read(pos, b, offset, len);
+        return n;
+    }
+
+    @Override
+    public long readToByteChannel(WritableByteChannel dest, long offset, long nbytes)
+            throws IOException
+    {
+        long need = nbytes;
+        byte[] buf = new byte[4096];
+
+        hfile.seek(offset);
+        int count = 0;
+        while (need > 0 && count != -1) {
+            need -= count;
+            dest.write(ByteBuffer.wrap(buf, 0, count));
+            count = hfile.read(buf, 0, 4096);
+        }
+        return nbytes - need;
+    }
+}

--- a/core/src/main/java/org/apache/sedona/core/formatMapper/netcdfParser/SerNetCDFUtils.java
+++ b/core/src/main/java/org/apache/sedona/core/formatMapper/netcdfParser/SerNetCDFUtils.java
@@ -1,0 +1,202 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*
+ * The following content is a Java rewrite version of SciSpark NetCDFUtils.scala which is under Apache License.
+ * SciSpark project is hosted on GitHub: https://github.com/SciSpark/SciSpark
+ * Written by Jia Yu (jiayu@apache.org).
+ * The Java version also contains more functions. Please refer to SerNetCDF README for more function details.
+ * 1. getDataSym(): get an observation from a symmetric mapping. One observation maps one geo-location
+ * 2. getDataAsym(): get an observation from a asymmetric mapping. One geolocation maps more than one observation.
+ * Or, one observation maps more than one geolocation
+ * 3. SerNetCDF doesn't force user to do 2D->1D array transformation. Because observations array does not follow
+ *  asymmetric mapping, many of the observations are actually not used at all. It is no need to convert them at the
+ *  beginning. It will directly jump to the desired array cell with O(1) complexity.
+ * 4. SerNetCDF considers hdf increment and hdf offset. These two variables control the mapping between geolocations and observations.
+ */
+package org.apache.sedona.core.formatMapper.netcdfParser;
+
+import ucar.ma2.Array;
+import ucar.ma2.Index;
+import ucar.nc2.Dimension;
+import ucar.nc2.NetcdfFile;
+import ucar.nc2.Variable;
+import ucar.nc2.dataset.NetcdfDataset;
+import ucar.nc2.dataset.NetcdfDatasets;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.Iterator;
+
+/**
+ * The Class SerNetCDFUtils.
+ */
+public class SerNetCDFUtils
+        implements Serializable
+{
+
+    /**
+     * Extracts a variable's data from a NetCDF.
+     * <p>
+     * If the variable is not found then an Array with the element 0.0
+     * is returned with shape (1,1). Note that all dimensions of size 1 are eliminated.
+     * For example the array shape (21, 5, 1, 2) is reduced to (21, 5, 2) since the 3rd dimension
+     * only ranges over a single value.
+     *
+     * @param netcdfFile The NetCDF file.
+     * @param variable The variable whose data we want to extract.
+     * @return 2D Data array.
+     */
+    public static Array getNetCDF2DArray(NetcdfDataset netcdfFile, String variable)
+    {
+        Variable netcdfVal = netcdfFile.findVariable(variable);
+        Array searchVariable = null;
+        try {
+            searchVariable = netcdfVal.read();
+        }
+        catch (Exception e) {
+            // TODO Auto-generated catch block
+            e.printStackTrace();
+        }
+        return searchVariable;
+    }
+
+    /**
+     * Gets the data from asymmetric mapping. One geolocation maps more than one observation.
+     * Or, one observation maps more than one geolocation.
+     *
+     * @param array the array
+     * @param i the i
+     * @param j the j
+     * @param offset the offset
+     * @param increment the increment
+     * @return the data asym
+     */
+    public static Double getDataAsym(Array array, int i, int j, int offset, int increment)
+    {
+        Index dataIndex = Index.factory(array.getShape());
+        int[] location = {offset + i * increment, offset + j * increment};
+        dataIndex.set(location);
+        switch (array.getDataType()) {
+            case INT:
+                return new Double((Integer) array.getObject(dataIndex));
+            case SHORT:
+                return new Double((Short) array.getObject(dataIndex));
+            case FLOAT:
+                return new Double((Float) array.getObject(dataIndex));
+            case DOUBLE:
+                return new Double((Double) array.getObject(dataIndex));
+            case LONG:
+                return new Double((Long) array.getObject(dataIndex));
+            default:
+                return (Double) array.getObject(dataIndex);
+        }
+    }
+
+    /**
+     * Gets the data from symmetric mapping. One geolocation maps one observation.
+     *
+     * @param array the array
+     * @param i the i
+     * @param j the j
+     * @return the data sym
+     */
+    public static Double getDataSym(Array array, int i, int j)
+    {
+        Index dataIndex = Index.factory(array.getShape());
+        int[] location = {i, j};
+        dataIndex.set(location);
+        switch (array.getDataType()) {
+            case INT:
+                return new Double((Integer) array.getObject(dataIndex));
+            case SHORT:
+                return new Double((Short) array.getObject(dataIndex));
+            case FLOAT:
+                return new Double((Float) array.getObject(dataIndex));
+            case DOUBLE:
+                return new Double((Double) array.getObject(dataIndex));
+            case LONG:
+                return new Double((Long) array.getObject(dataIndex));
+            default:
+                return (Double) array.getObject(dataIndex);
+        }
+    }
+
+    /**
+     * Loads a NetCDF Dataset from a URL.
+     *
+     * @param url the url
+     * @return the netcdf dataset
+     */
+    public static NetcdfDataset loadNetCDFDataSet(String url)
+    {
+        NetcdfDataset dataset = null;
+        try {
+            dataset = NetcdfDatasets.openDataset(url);
+        }
+        catch (IOException e) {
+            e.printStackTrace();
+        }
+        catch (Exception e) {
+            e.printStackTrace();
+        }
+        return dataset;
+    }
+
+    /**
+     * Loads a NetCDF Dataset from HDFS.
+     *
+     * @param dfsUri HDFS URI(eg. hdfs://master:9000/)
+     * @param location File path on HDFS
+     * @param bufferSize The size of the buffer to be used
+     * @return the netcdf dataset
+     */
+    public static NetcdfDataset loadDFSNetCDFDataSet(String dfsUri, String location, Integer bufferSize)
+    {
+        NetcdfDataset dataset = null;
+        try {
+            HDFSRandomAccessFile raf = new HDFSRandomAccessFile(dfsUri, location, bufferSize);
+            dataset = new NetcdfDataset(NetcdfFile.open(raf, location, null, null));
+        }
+        catch (IOException e) {
+            e.printStackTrace();
+        }
+        catch (Exception e) {
+            e.printStackTrace();
+        }
+        return dataset;
+    }
+
+    /**
+     * Gets the size of a dimension of a NetCDF file.
+     *
+     * @param netcdfFile the netcdf file
+     * @param rowDim the row dim
+     * @return the dimension size
+     */
+    public static Integer getDimensionSize(NetcdfDataset netcdfFile, String rowDim)
+    {
+        int dimSize = -1;
+        Iterator<Dimension> it = netcdfFile.getDimensions().iterator();
+        while (it.hasNext()) {
+            Dimension d = it.next();
+			if (d.getShortName().equals(rowDim)) {dimSize = d.getLength();}
+        }
+		if (dimSize < 0) {throw new IllegalStateException("Dimension does not exist!!!");}
+        return dimSize;
+    }
+}

--- a/core/src/test/java/org/apache/sedona/core/formatMapper/testSerNetCDF.java
+++ b/core/src/test/java/org/apache/sedona/core/formatMapper/testSerNetCDF.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.sedona.core.formatMapper;
+
+import static org.junit.Assert.*;
+
+import java.util.List;
+
+import org.apache.sedona.core.formatMapper.netcdfParser.SerNetCDFUtils;
+import org.junit.After;
+import org.junit.BeforeClass;
+import org.junit.Ignore;
+import org.junit.Test;
+
+
+import ucar.ma2.Array;
+import ucar.nc2.Variable;
+import ucar.nc2.dataset.NetcdfDataset;
+
+/**
+ * The following tests currently have no effect as we plan to implement all raster formats in DataFrame styles and deprecate all Netcdf support
+ */
+public class testSerNetCDF {
+
+	static String filename = "";
+	@BeforeClass
+	public static void setUpBeforeClass() throws Exception {
+//		filename = System.getProperty("user.dir")+"/src/test/resources/" + "MYD11_L2.A2017091.0155.006.2017094143610.hdf";
+	}
+
+	@After
+	public void tearDown() throws Exception {
+	}
+
+	@Ignore
+	public void test() {
+		NetcdfDataset ncfile = null;		
+		int offset = 2;
+		int increment = 5;
+		double scaleFactor = 0.02;
+		
+		String swathName = "MOD_Swath_LST";
+		String geolocationFieldName = "Geolocation_Fields";
+		String dataFieldName = "Data_Fields";
+		String dataVariableName = "LST";
+		ncfile =  SerNetCDFUtils.loadNetCDFDataSet(filename);
+		
+		List<Variable> variables = ncfile.getVariables();
+		Array longitude = SerNetCDFUtils.getNetCDF2DArray(ncfile, swathName+"/"+geolocationFieldName+"/Longitude");
+		Array latitude = SerNetCDFUtils.getNetCDF2DArray(ncfile, swathName+"/"+geolocationFieldName+"/Latitude");
+		Array dataVariable = SerNetCDFUtils.getNetCDF2DArray(ncfile, swathName+"/"+dataFieldName+"/"+dataVariableName);
+		int[] geolocationShape = longitude.getShape();
+		
+		for (int j = 0; j < geolocationShape[0]; j++) {
+			for (int i = 0; i < geolocationShape[1]; i++) {
+				// We probably need to switch longitude and latitude if needed.
+				double lng = SerNetCDFUtils.getDataSym(longitude, j, i);
+				double lat = SerNetCDFUtils.getDataSym(latitude, j, i);
+				String userData = String.valueOf(SerNetCDFUtils.getDataAsym(dataVariable, j, i, offset, increment));
+			}
+		}
+		    
+	}
+
+}

--- a/docs/setup/maven-coordinates.md
+++ b/docs/setup/maven-coordinates.md
@@ -81,22 +81,51 @@ The optional GeoTools library is required only if you want to use CRS transforma
 		```
 
 
-#### SernetCDF 0.1.0
+### netCDF-Java 5.4.2
 
 For Scala / Java API, it is required only if you want to read HDF/NetCDF files.
 
-HDF/NetCDF function is currently not supported in Sedona Python.
+HDF/NetCDF function is only supported in Spark RDD with Java/Scala API. The current function is deprecated and more mature support will be released soon.
 
-Under Apache License 2.0.
+Under BSD 3-clause (compatible with Apache 2.0 license)
 
-```xml
-<!-- https://mvnrepository.com/artifact/org.datasyslab/sernetcdf -->
-<dependency>
-    <groupId>org.datasyslab</groupId>
-    <artifactId>sernetcdf</artifactId>
-    <version>0.1.0</version>
-</dependency>
-```
+!!! abstract "Add HDF/NetCDF dependency"
+
+	=== "Sedona 1.3.1+"
+
+		Add unidata repo to your POM.xml
+		
+		```
+		<repositories>
+		    <repository>
+		        <id>unidata-all</id>
+		        <name>Unidata All</name>
+		        <url>https://artifacts.unidata.ucar.edu/repository/unidata-all/</url>
+		    </repository>
+		</repositories>
+		```
+		
+		Then add cdm-core to your POM dependency.
+		
+		```xml
+		<dependency>
+		    <groupId>edu.ucar</groupId>
+		    <artifactId>cdm-core</artifactId>
+		    <version>5.4.2</version>
+		</dependency>
+		```
+
+	=== "Before Sedona 1.3.1"
+	
+		```xml
+		<!-- https://mvnrepository.com/artifact/org.datasyslab/sernetcdf -->
+		<dependency>
+		    <groupId>org.datasyslab</groupId>
+		    <artifactId>sernetcdf</artifactId>
+		    <version>0.1.0</version>
+		</dependency>
+		```
+
 
 ## Use Sedona and third-party jars separately
 
@@ -123,46 +152,27 @@ Under Apache License 2.0.
 		  <version>{{ sedona.current_version }}</version>
 		</dependency>
 		```
-	
-	=== "Spark 2.4 and Scala 2.11"
-	
-		```xml
-		<dependency>
-		  <groupId>org.apache.sedona</groupId>
-		  <artifactId>sedona-core-2.4_2.11</artifactId>
-		  <version>{{ sedona.current_version }}</version>
-		</dependency>
-		<dependency>
-		  <groupId>org.apache.sedona</groupId>
-		  <artifactId>sedona-sql-2.4_2.11</artifactId>
-		  <version>{{ sedona.current_version }}</version>
-		</dependency>
-		<dependency>
-		  <groupId>org.apache.sedona</groupId>
-		  <artifactId>sedona-viz-2.4_2.11</artifactId>
-		  <version>{{ sedona.current_version }}</version>
-		</dependency>
-		```
-	
-	=== "Spark 2.4 and Scala 2.12"
+	=== "Spark 3.0+ and Scala 2.13"
 	
 		```xml
 		<dependency>
 		  <groupId>org.apache.sedona</groupId>
-		  <artifactId>sedona-core-2.4_2.12</artifactId>
+		  <artifactId>sedona-core-3.0_2.13</artifactId>
 		  <version>{{ sedona.current_version }}</version>
 		</dependency>
 		<dependency>
 		  <groupId>org.apache.sedona</groupId>
-		  <artifactId>sedona-sql-2.4_2.12</artifactId>
+		  <artifactId>sedona-sql-3.0_2.13</artifactId>
 		  <version>{{ sedona.current_version }}</version>
 		</dependency>
 		<dependency>
 		  <groupId>org.apache.sedona</groupId>
-		  <artifactId>sedona-viz-2.4_2.12</artifactId>
+		  <artifactId>sedona-viz-3.0_2.13</artifactId>
 		  <version>{{ sedona.current_version }}</version>
 		</dependency>
 		```
+		
+	
 
 !!! abstract "Sedona with Apache Flink"
 
@@ -235,20 +245,50 @@ GeoTools library is required only if you want to use CRS transformation and Shap
 </dependency>
 ```
 
-### SernetCDF 0.1.0
+### netCDF-Java 5.4.2
 
-For Scala / Java API: `required` if you want to read HDF files.
+For Scala / Java API, it is required only if you want to read HDF/NetCDF files.
 
-Under Apache License 2.0.
+HDF/NetCDF function is only supported in Spark RDD with Java/Scala API. The current function is deprecated and more mature support will be released soon.
 
-```xml
-<!-- https://mvnrepository.com/artifact/org.datasyslab/sernetcdf -->
-<dependency>
-    <groupId>org.datasyslab</groupId>
-    <artifactId>sernetcdf</artifactId>
-    <version>0.1.0</version>
-</dependency>
-```
+Under BSD 3-clause (compatible with Apache 2.0 license)
+
+!!! abstract "Add HDF/NetCDF dependency"
+
+	=== "Sedona 1.3.1+"
+
+		Add unidata repo to your POM.xml
+		
+		```
+		<repositories>
+		    <repository>
+		        <id>unidata-all</id>
+		        <name>Unidata All</name>
+		        <url>https://artifacts.unidata.ucar.edu/repository/unidata-all/</url>
+		    </repository>
+		</repositories>
+		```
+		
+		Then add cdm-core to your POM dependency.
+		
+		```xml
+		<dependency>
+		    <groupId>edu.ucar</groupId>
+		    <artifactId>cdm-core</artifactId>
+		    <version>5.4.2</version>
+		</dependency>
+		```
+
+	=== "Before Sedona 1.3.1"
+	
+		```xml
+		<!-- https://mvnrepository.com/artifact/org.datasyslab/sernetcdf -->
+		<dependency>
+		    <groupId>org.datasyslab</groupId>
+		    <artifactId>sernetcdf</artifactId>
+		    <version>0.1.0</version>
+		</dependency>
+		```
 
 ## SNAPSHOT versions
 Sometimes Sedona has a SNAPSHOT version for the upcoming release. It follows the same naming conversion but has "SNAPSHOT" as suffix in the version. For example, `{{ sedona.current_snapshot }}`

--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,7 @@
         <dependency.scope>provided</dependency.scope>
         <jts.version>1.18.2</jts.version>
         <jts2geojson.version>0.16.1</jts2geojson.version>
+        <netcdf.version>5.4.2</netcdf.version>
         <spark.version>3.3.0</spark.version>
         <spark.compat.version>3.0</spark.compat.version>
         <sedona.jackson.version>2.13.3</sedona.jackson.version>
@@ -127,9 +128,9 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>org.datasyslab</groupId>
-            <artifactId>sernetcdf</artifactId>
-            <version>0.1.0</version>
+            <groupId>edu.ucar</groupId>
+            <artifactId>cdm-core</artifactId>
+            <version>${netcdf.version}</version>
             <scope>${dependency.scope}</scope>
         </dependency>
         <!--The following GeoTools dependencies use GNU Lesser General Public License and thus are excluded from the binary distribution-->
@@ -246,6 +247,11 @@
             <releases>
                 <enabled>true</enabled>
             </releases>
+        </repository>
+        <repository>
+            <id>unidata-all</id>
+            <name>Unidata All</name>
+            <url>https://artifacts.unidata.ucar.edu/repository/unidata-all/</url>
         </repository>
     </repositories>
     <build>
@@ -386,7 +392,7 @@
                                     </excludes>
                                 </filter>
                                 <filter>
-                                    <artifact>org.datasyslab:sernetcdf</artifact>
+                                    <artifact>edu.ucar:cdm-core</artifact>
                                     <excludes>
                                         <exclude>com/fasterxml/**</exclude>
                                     </excludes>

--- a/pom.xml
+++ b/pom.xml
@@ -252,6 +252,12 @@
             <id>unidata-all</id>
             <name>Unidata All</name>
             <url>https://artifacts.unidata.ucar.edu/repository/unidata-all/</url>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
         </repository>
     </repositories>
     <build>

--- a/viz/pom.xml
+++ b/viz/pom.xml
@@ -56,8 +56,8 @@
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>
-            <artifactId>aws-java-sdk</artifactId>
-            <version>1.7.4</version>
+            <artifactId>aws-java-sdk-s3</artifactId>
+            <version>1.12.362</version>
             <scope>${dependency.scope}</scope>
             <exclusions>
                 <exclusion>


### PR DESCRIPTION

## Did you read the Contributor Guide?

- Yes, I have read [Contributor Rules](https://sedona.apache.org/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/community/develop/)

## Is this PR related to a JIRA ticket?

- Yes, the URL of the assoicated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-194. The PR name follows the format `[SEDONA-194] my subject`.


## What changes were proposed in this PR?

1. Move SerNetCDF to Sedona
2. Add unidata repo and cdm-core to Sedona dependency
3. Remove the shaded SerNetCDF dependency

## How was this patch tested?

No actual tests are added. Reason:
1. We deprecated HDF/NetCDF support in Spark RDD.
2. We plan to launch more mature support for different raster formats in DataFrame

## Did this PR include necessary documentation updates?

- Yes, I have updated the documentation update.