### PR TITLE
[SEDONA-218] Fix a flaky test caused by improper handling of null struct values in `Adapter.toDf`

### DIFF
--- a/sql/src/main/scala/org/apache/sedona/sql/utils/Adapter.scala
+++ b/sql/src/main/scala/org/apache/sedona/sql/utils/Adapter.scala
@@ -295,6 +295,7 @@ object Adapter {
         case _: TimestampType => null.asInstanceOf[Timestamp]
         case _: BooleanType => null.asInstanceOf[Boolean]
         case _: StringType => null.asInstanceOf[String]
+        case _: StructType => null.asInstanceOf[StructType]
       }
     }
 

--- a/sql/src/test/scala/org/apache/sedona/sql/adapterTestScala.scala
+++ b/sql/src/test/scala/org/apache/sedona/sql/adapterTestScala.scala
@@ -349,7 +349,7 @@ class adapterTestScala extends TestBaseScala with GivenWhenThen{
       // a serialization error if the schema or coercion is incorrect, e.g.
       // "Error while encoding: java.lang.RuntimeException: <desired data type> is not a
       // valid external type for schema of <current data type>"
-      println(joinResultDf.show(1))
+      joinResultDf.foreach(r => ())
 
       assert(
         joinResultDf.schema == schema,


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read [Contributor Rules](https://sedona.apache.org/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/community/develop/)

## Is this PR related to a JIRA ticket?

- Yes, the URL of the assoicated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-218. The PR name follows the format `[SEDONA-218] my subject`.

## What changes were proposed in this PR?

Handle null struct values properly in `Adapter.toDF` and fix related flaky tests. Please refer to the JIRA ticket for details.

## How was this patch tested?

The flaky unit test fails randomly since it has non-deterministic behavior, we make it deterministic and pass consistently in this patch.

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the docs.
